### PR TITLE
DI-264 Invalid Postcode does not prevent Address Updates

### DIFF
--- a/application/event_processor/changes.py
+++ b/application/event_processor/changes.py
@@ -27,8 +27,8 @@ def get_changes(dos_service: DoSService, nhs_entity: NHSEntity) -> Dict[str, str
     update_changes(changes, WEBSITE_CHANGE_KEY, dos_service.web, nhs_entity.website)
     update_changes(changes, PHONE_CHANGE_KEY, dos_service.publicphone, nhs_entity.phone)
     update_changes(changes, PUBLICNAME_CHANGE_KEY, dos_service.publicname, nhs_entity.org_name)
-    update_changes_with_postcode(changes, dos_service, nhs_entity)
     update_changes_with_address(changes, dos_service, nhs_entity)
+    update_changes_with_postcode(changes, dos_service, nhs_entity)
     update_changes_with_opening_times(changes, dos_service, nhs_entity)
     return changes
 
@@ -115,5 +115,13 @@ def update_changes_with_postcode(changes: dict, dos_service: DoSService, nhs_ent
         valid_dos_postcode = get_valid_dos_postcode(nhs_postcode)
         if valid_dos_postcode is None:
             log_invalid_nhsuk_pharmacy_postcode(nhs_entity, dos_service)
+            try:
+                if changes[ADDRESS_CHANGE_KEY]:
+                    del changes[ADDRESS_CHANGE_KEY]
+                    logger.info("Deleted address change as postcode is invalid")
+            except KeyError:
+                logger.info(
+                    "Attempted to delete address change as postcode is invalid however address change does not exist"
+                )
         else:
             changes[POSTCODE_CHANGE_KEY] = valid_dos_postcode

--- a/application/event_processor/tests/test_changes.py
+++ b/application/event_processor/tests/test_changes.py
@@ -173,8 +173,22 @@ def test_do_not_update_address_if_postcode_invalid(mock_get_valid_dos_postcode, 
     nhs_entity = NHSEntity(change_event)
     dos_service = dummy_dos_service()
     mock_get_valid_dos_postcode.return_value = None
-    # Act
     existing_changes = {ADDRESS_CHANGE_KEY: ["address1", "address2", "address3", "city", "county"]}
+    # Act
+    update_changes_with_postcode(existing_changes, dos_service, nhs_entity)
+    # Assert
+    mock_get_valid_dos_postcode.assert_called_once_with(nhs_entity.normal_postcode())
+    assert existing_changes == {}, f"Should return empty dict, actually: {existing_changes}"
+
+
+@patch(f"{FILE_PATH}.get_valid_dos_postcode")
+def test_do_not_update_address_if_postcode_invalid_no_address(mock_get_valid_dos_postcode, change_event):
+    # Arrange
+    nhs_entity = NHSEntity(change_event)
+    dos_service = dummy_dos_service()
+    mock_get_valid_dos_postcode.return_value = None
+    existing_changes = {}
+    # Act
     update_changes_with_postcode(existing_changes, dos_service, nhs_entity)
     # Assert
     mock_get_valid_dos_postcode.assert_called_once_with(nhs_entity.normal_postcode())

--- a/build/automation/var/profile/dev.mk
+++ b/build/automation/var/profile/dev.mk
@@ -3,6 +3,8 @@
 # ==============================================================================
 # Service variables
 
+LOG_LEVEL:= INFO
+
 DOS_API_GATEWAY_SECRETS = $(TF_VAR_dos_api_gateway_secret)
 DOS_API_GATEWAY_USERNAME_KEY := DOS_API_GATEWAY_USERNAME
 DOS_API_GATEWAY_PASSWORD_KEY := DOS_API_GATEWAY_PASSWORD

--- a/build/automation/var/profile/task.mk
+++ b/build/automation/var/profile/task.mk
@@ -3,6 +3,8 @@
 # ==============================================================================
 # Service variables
 
+LOG_LEVEL:= DEBUG
+
 DOS_API_GATEWAY_SECRETS = $(TF_VAR_dos_api_gateway_secret)
 DOS_API_GATEWAY_USERNAME_KEY := DOS_API_GATEWAY_USERNAME
 DOS_API_GATEWAY_PASSWORD_KEY := DOS_API_GATEWAY_PASSWORD

--- a/deployment/serverless.yml
+++ b/deployment/serverless.yml
@@ -25,6 +25,7 @@ provider:
     POWERTOOLS_TRACER_CAPTURE_RESPONSE: true
     POWERTOOLS_TRACER_CAPTURE_ERROR: true
     POWERTOOLS_TRACE_MIDDLEWARES: true
+    LOG_LEVEL: ${env:LOG_LEVEL}
   tracing:
     lambda: true
     apiGateway: true


### PR DESCRIPTION
## Link to JIRA Ticket

- https://nhsd-jira.digital.nhs.uk/browse/DI-264

## Description

This make sure if the postcode is invalid then the address is removed from the change request

## Type of change

Delete not appropriate

- Bug fix (non-breaking change which fixes an issue)

## Testing

Please tick the testing that has been completed

- [x] Unit tests

## Developer Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the [code formatting checks](../README.md#code-quality)
- [x] I have run the [code quality checks](../README.md#code-quality)
- [x] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [x] Unit test code coverage is at or above 80%
- [x] New and existing unit tests pass locally with my changes
- [x] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [x] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
