### PR TITLE
DI-294 Add dynamo db Query operation

### DIFF
--- a/test/integration/features/parent_features.feature
+++ b/test/integration/features/parent_features.feature
@@ -14,7 +14,7 @@ Feature: DOS INTEGRATION E2E TESTS
     And the unmatched service exception is reported to cloudwatch
     Then the Changed Event is not processed any further
 
-  @complete @dev
+@complete @dev
   Scenario: ALL RECEIVED CHANGED EVENT IS ARCHIVED IN DYNAMO DB
     Given a Changed Event is valid
     When the Changed Event is sent for processing

--- a/test/integration/features/steps/parent_steps.py
+++ b/test/integration/features/steps/parent_steps.py
@@ -5,7 +5,6 @@ from features.utilities.utils import (
     get_stored_events_from_dynamo_db,
     search_dos_db,
 )
-from decimal import Decimal
 from features.utilities.change_events import get_change_event
 from features.utilities.log_stream import get_logs
 
@@ -75,7 +74,9 @@ def stored_dynamo_db_events_are_pulled(context):
     db_event_record = get_stored_events_from_dynamo_db(odscode)
     assert db_event_record is not None, f"ERROR!! Event record with odscode {odscode} NOT found!.."
     assert odscode == str(db_event_record["ODSCode"]["S"]), "ERROR!!.. Change event record(odscode) mismatch!!"
-    assert sequence_num == int(db_event_record["SequenceNumber"]["N"]), "ERROR!!.. Change event record(sequence no) mismatch!!"
+    assert sequence_num == int(
+        db_event_record["SequenceNumber"]["N"]
+    ), "ERROR!!.. Change event record(sequence no) mismatch!!"
 
 
 @then("the lambda is confirmed active")

--- a/test/integration/features/steps/parent_steps.py
+++ b/test/integration/features/steps/parent_steps.py
@@ -71,11 +71,11 @@ def the_lambda_logs_are_generated(context, event: str):
 @then("the Changed Event is stored in dynamo db")
 def stored_dynamo_db_events_are_pulled(context):
     odscode = context.change_event["ODSCode"]
-    sequence_num = Decimal(context.sequence_no)
-    db_event_record = get_stored_events_from_dynamo_db(odscode, sequence_num)
+    sequence_num = int(context.sequence_no)
+    db_event_record = get_stored_events_from_dynamo_db(odscode)
     assert db_event_record is not None, f"ERROR!! Event record with odscode {odscode} NOT found!.."
-    assert odscode == db_event_record["ODSCode"], "ERROR!!.. Change event record(odscode) mismatch!!"
-    assert sequence_num == db_event_record["SequenceNumber"], "ERROR!!.. Change event record(sequence no) mismatch!!"
+    assert odscode == str(db_event_record["ODSCode"]["S"]), "ERROR!!.. Change event record(odscode) mismatch!!"
+    assert sequence_num == int(db_event_record["SequenceNumber"]["N"]), "ERROR!!.. Change event record(sequence no) mismatch!!"
 
 
 @then("the lambda is confirmed active")

--- a/test/integration/features/utilities/utils.py
+++ b/test/integration/features/utilities/utils.py
@@ -5,9 +5,7 @@ from features.utilities.get_secrets import get_secret
 from json import dumps
 from boto3 import client
 from time import sleep
-from decimal import Decimal
 import boto3
-from boto3.dynamodb.conditions import Attr, Key
 import psycopg2
 from psycopg2.extras import DictCursor
 
@@ -44,15 +42,15 @@ def debug_purge_queue():
 
 def get_stored_events_from_dynamo_db(odscode: str) -> dict:
     resp = DYNAMO_CLIENT.query(
-    TableName=DYNAMO_DB_TABLE,
-    IndexName="gsi_ods_sequence",
-    KeyConditionExpression="ODSCode = :odscode",
-    ExpressionAttributeValues={
-        ":odscode": {"S": odscode},
-    },
-    Limit=1,
-    ScanIndexForward=False,
-    ProjectionExpression="ODSCode,SequenceNumber",
+        TableName=DYNAMO_DB_TABLE,
+        IndexName="gsi_ods_sequence",
+        KeyConditionExpression="ODSCode = :odscode",
+        ExpressionAttributeValues={
+            ":odscode": {"S": odscode},
+        },
+        Limit=1,
+        ScanIndexForward=False,
+        ProjectionExpression="ODSCode,SequenceNumber",
     )
     item = resp["Items"][0]
     return item


### PR DESCRIPTION
## Link to JIRA Ticket
https://nhsd-jira.digital.nhs.uk/browse/DI-294
-

## Description

The purpose of this ticket is to replace the existing Scan operation with Query operation when fetching items from the DB
### Noteworthy Changes

The "get_stored_events_from_dynamo_db()" function was refactored.

## Type of change

Delete not appropriate

- New feature (non-breaking change which adds functionality)

## Testing

Please tick the testing that has been completed

- [ ] Unit tests
- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Component tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
