### PR TITLE
Rework the encryption store key as global for speed

### DIFF
--- a/application/common/encryption_helper.py
+++ b/application/common/encryption_helper.py
@@ -1,0 +1,44 @@
+from aws_encryption_sdk import CommitmentPolicy, EncryptionSDKClient, StrictAwsKmsMasterKeyProvider
+from aws_lambda_powertools import Logger
+from boto3 import client
+from os import environ
+
+logger = Logger(child=True)
+
+
+class MessageEncryptionHelper:
+    """Class to represent a MessageEncryptionHelper"""
+
+    def __init__(self) -> None:
+
+        logger.info("Getting key")
+        kms = client("kms")
+        response = kms.describe_key(
+            KeyId=f"alias/{environ['KEYALIAS']}",
+            GrantTokens=[
+                "string",
+            ],
+        )
+        # Use the key arn you obtained in the previous step
+        key_arn = response["KeyMetadata"]["Arn"]
+        self._encryption_client = EncryptionSDKClient(
+            commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+        )
+
+        # Create an AWS KMS master key provider
+        kms_kwargs = dict(key_ids=[key_arn])
+
+        self._master_key_provider = StrictAwsKmsMasterKeyProvider(**kms_kwargs)
+
+    def encrypt_string(self, plaintext):
+        encrypted_text, encryptor_header = self._encryption_client.encrypt(
+            source=plaintext, key_provider=self._master_key_provider
+        )
+        return encrypted_text
+
+    def decrypt_string(self, ciphertext):
+
+        decrypted_text, encryptor_header = self._encryption_client.decrypt(
+            source=ciphertext, key_provider=self._master_key_provider
+        )
+        return decrypted_text.decode()

--- a/application/event_processor/tests/test_event_processor.py
+++ b/application/event_processor/tests/test_event_processor.py
@@ -5,7 +5,7 @@ from random import choices
 from change_event_exceptions import ValidationException
 from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
 from aws_lambda_powertools import Logger
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 
 from pytest import fixture, raises
@@ -177,7 +177,11 @@ def test_send_changes(mock_client, mock_logger, get_correlation_id_mock, encrypt
     # Arrange
     bus_name = "test"
     environ["EVENTBRIDGE_BUS_NAME"] = bus_name
-    encryption_client_mock.return_value = (lambda a: b"encrypted", lambda a: "decrypted")
+    mock_e = Mock()
+    mock_e.encrypt_string = lambda a: b"encrypted"
+    mock_e.decrypt_string = lambda a: "decrypted"
+    mock_client.return_value = mock_e
+    encryption_client_mock.return_value = mock_e
     change_request = ChangeRequest(service_id=49016)
     change_request.reference = "1"
     change_request.system = "Profile Updater (test)"
@@ -232,7 +236,11 @@ def test_send_changes_when_get_change_requests_not_run(mock_client, mock_logger,
     # Arrange
     record_id = "someid"
     message_received = 1642501355616
-    encryption_client_mock.return_value = (lambda a: b"encrypted", lambda a: "decrypted")
+    mock_e = Mock()
+    mock_e.encrypt_string = lambda a: b"encrypted"
+    mock_e.decrypt_string = lambda a: "decrypted"
+    mock_client.return_value = mock_e
+    encryption_client_mock.return_value = mock_e
     nhs_entity = NHSEntity({})
     nhs_entity.odscode = "SLC45"
     nhs_entity.website = "www.site.com"
@@ -257,7 +265,11 @@ def test_send_changes_when_no_change_requests(mock_client, mock_logger, encrypti
     record_id = "someid"
     message_received = 1642501355616
     nhs_entity = NHSEntity({})
-    encryption_client_mock.return_value = (lambda a: b"encrypted", lambda a: "decrypted")
+    mock_e = Mock()
+    mock_e.encrypt_string = lambda a: b"encrypted"
+    mock_e.decrypt_string = lambda a: "decrypted"
+    mock_client.return_value = mock_e
+    encryption_client_mock.return_value = mock_e
     nhs_entity.odscode = "SLC45"
     nhs_entity.website = "www.site.com"
     nhs_entity.phone = "01462622435"

--- a/infrastructure/stacks/development-pipeline/policies.tf
+++ b/infrastructure/stacks/development-pipeline/policies.tf
@@ -124,7 +124,10 @@ resource "aws_iam_role_policy" "codebuild_policy" {
     },
     {
         "Effect": "Allow",
-        "Action": "logs:DescribeLogGroups",
+        "Action": [
+          "logs:DescribeLogGroups",
+          "logs:GetQueryResults"
+        ],
         "Resource": "arn:aws:logs:${var.aws_region}:${var.aws_account_id_nonprod}:log-group::log-stream:"
     },
     {


### PR DESCRIPTION
## Link to JIRA Ticket

-

## Description

Did some refactoring to the encryption stuff so that they key is global so that it only got once per container creation

## Type of change

Delete not appropriate

- Refactor

## Testing

Please tick the testing that has been completed

- [ ] Unit tests
- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
