### PR TITLE
Allow setting number of parallel tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,10 +115,10 @@ smoke-test: #Integration Smoke test for DI project - mandatory: PROFILE, ENVIRON
 		-e RUN_ID=${RUN_ID} \
 		"
 
-integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[complete|dev]; optional: ENVIRONMENT
+integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[complete|dev]; optional: ENVIRONMENT, PARALLEL_TEST_COUNT=
 	make -s docker-run-tools \
 	IMAGE=$$(make _docker-get-reg)/tester \
-	CMD="pytest steps -k $(TAGS) -vv --gherkin-terminal-reporter -p no:sugar -n auto --junitxml=./testresults.xml --disable-pytest-warnings" \
+	CMD="pytest steps -k $(TAGS) -vv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --junitxml=./testresults.xml --disable-pytest-warnings" \
 	DIR=./test/integration \
 	ARGS=" \
 		-e API_KEY_SECRET=$(TF_VAR_api_gateway_api_key_name) \
@@ -458,7 +458,7 @@ stress-test-in-pipeline: # An all in one stress test make target
 	AWS_START_TIME=$$(date +%FT%TZ)
 	CODE_VERSION=$$($(AWSCLI) lambda get-function --function-name $(TF_VAR_event_processor_lambda_name) | jq --raw-output '.Configuration.Environment.Variables.CODE_VERSION')
 	make stress-test START_TIME=$$START_TIME PIPELINE=true
-	sleep 6h
+	sleep 4.5h
 	END_TIME=$$(date +%Y-%m-%d_%H-%M-%S)
 	AWS_END_TIME=$$(date +%FT%TZ)
 	make performance-test-data-collection START_TIME=$$START_TIME END_TIME=$$END_TIME
@@ -470,7 +470,7 @@ load-test-in-pipeline: # An all in one load test make target
 	AWS_START_TIME=$$(date +%FT%TZ)
 	CODE_VERSION=$$($(AWSCLI) lambda get-function --function-name $(TF_VAR_event_processor_lambda_name) | jq --raw-output '.Configuration.Environment.Variables.CODE_VERSION')
 	make load-test START_TIME=$$START_TIME
-	sleep 25m
+	sleep 10m
 	END_TIME=$$(date +%Y-%m-%d_%H-%M-%S)
 	AWS_END_TIME=$$(date +%FT%TZ)
 	make performance-test-data-collection START_TIME=$$START_TIME END_TIME=$$END_TIME

--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ smoke-test: #Integration Smoke test for DI project - mandatory: PROFILE, ENVIRON
 integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[complete|dev]; optional: ENVIRONMENT, PARALLEL_TEST_COUNT
 	make -s docker-run-tools \
 	IMAGE=$$(make _docker-get-reg)/tester \
-	CMD="pytest steps -k $(TAGS) -vv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --junitxml=./testresults.xml --disable-pytest-warnings" \
+	CMD="pytest steps -k $(TAGS) -vv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --junitxml=./testresults.xml" \
 	DIR=./test/integration \
 	ARGS=" \
 		-e API_KEY_SECRET=$(TF_VAR_api_gateway_api_key_name) \

--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ smoke-test: #Integration Smoke test for DI project - mandatory: PROFILE, ENVIRON
 		-e RUN_ID=${RUN_ID} \
 		"
 
-integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[complete|dev]; optional: ENVIRONMENT, PARALLEL_TEST_COUNT=
+integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[complete|dev]; optional: ENVIRONMENT, PARALLEL_TEST_COUNT
 	make -s docker-run-tools \
 	IMAGE=$$(make _docker-get-reg)/tester \
 	CMD="pytest steps -k $(TAGS) -vv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --junitxml=./testresults.xml --disable-pytest-warnings" \

--- a/build/automation/var/project.mk
+++ b/build/automation/var/project.mk
@@ -30,3 +30,4 @@ TF_VAR_texas_hosted_zone = $(TEXAS_HOSTED_ZONE)
 TF_VAR_environment = $(ENVIRONMENT)
 TF_VAR_github_owner = nhsd-exeter
 TF_VAR_github_repo = dos-integration
+PARALLEL_TEST_COUNT := $(or $(PARALLEL_TEST_COUNT) auto)

--- a/infrastructure/stacks/development-pipeline/integration-tests-buildspec.yml
+++ b/infrastructure/stacks/development-pipeline/integration-tests-buildspec.yml
@@ -45,7 +45,7 @@ phases:
       - make tester-build
       - make update-ip-allowlist PROFILE=test ENVIRONMENT=test USERNAME="codebuild"
       - make terraform-apply-auto-approve STACKS=api-gateway-sqs PROFILE=test ENVIRONMENT=test
-      - make integration-test TAGS=complete PROFILE=test ENVIRONMENT=test RUN_ID=$CODEBUILD_RESOLVED_SOURCE_VERSION-$CODEBUILD_BUILD_NUMBER
+      - make integration-test TAGS=complete PROFILE=test ENVIRONMENT=test RUN_ID=$CODEBUILD_RESOLVED_SOURCE_VERSION-$CODEBUILD_BUILD_NUMBER PARALLEL_TEST_COUNT=8
   post_build:
     commands:
       - make delete-ip-from-allowlist PROFILE=test ENVIRONMENT=test USERNAME="codebuild"

--- a/infrastructure/stacks/development-pipeline/integration-tests-buildspec.yml
+++ b/infrastructure/stacks/development-pipeline/integration-tests-buildspec.yml
@@ -45,7 +45,7 @@ phases:
       - make tester-build
       - make update-ip-allowlist PROFILE=test ENVIRONMENT=test USERNAME="codebuild"
       - make terraform-apply-auto-approve STACKS=api-gateway-sqs PROFILE=test ENVIRONMENT=test
-      - make integration-test TAGS=complete PROFILE=test ENVIRONMENT=test RUN_ID=$CODEBUILD_RESOLVED_SOURCE_VERSION-$CODEBUILD_BUILD_NUMBER PARALLEL_TEST_COUNT=8
+      - make integration-test TAGS=complete PROFILE=test ENVIRONMENT=test RUN_ID=$CODEBUILD_RESOLVED_SOURCE_VERSION-$CODEBUILD_BUILD_NUMBER PARALLEL_TEST_COUNT=10
   post_build:
     commands:
       - make delete-ip-from-allowlist PROFILE=test ENVIRONMENT=test USERNAME="codebuild"

--- a/test/integration/steps/pytest.ini
+++ b/test/integration/steps/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+markers =
+    dev: Test that can be run on both task and dev environments.
+    complete: The full test suite.
+    smoke: Tests that can be run in Prod Environments.

--- a/test/integration/steps/pytest.ini
+++ b/test/integration/steps/pytest.ini
@@ -3,3 +3,5 @@ markers =
     dev: Test that can be run on both task and dev environments.
     complete: The full test suite.
     smoke: Tests that can be run in Prod Environments.
+    event_sender: Tests that test the event sender
+    security: Tests that test the security features

--- a/test/integration/steps/utilities/log_stream.py
+++ b/test/integration/steps/utilities/log_stream.py
@@ -61,7 +61,7 @@ def get_logs(query: str, event_lambda: str, start_time: Timestamp) -> str:
         counter += 1
         if response["results"] != []:
             logs_found = True
-        elif counter == 12:
+        elif counter == 16:
             raise Exception("Log search retries exceeded.. no logs found")
     return dumps(response, indent=2)
 


### PR DESCRIPTION
## Description

This PR allows for the integration tests to have the number of parallel tests count set by a variable. By default this is set to auto. Also it increases the delay for some tests to reduce failures. As well removes many pytest tag warnings.