### PR TITLE
DI-311 Report logging in event processor for invalid open times

### DIFF
--- a/application/event_processor/changes.py
+++ b/application/event_processor/changes.py
@@ -81,12 +81,12 @@ def update_changes_with_opening_times(changes: dict, dos_service: DoSService, nh
         nhs_entity (NHSEntity): NHS UK Entity for comparision
     """
 
-    # If anything in OpeningTimes list field doesn't appear right, no open times changes are created.
+    # Skip if invalid times. This check will have already been done and logged out fully in event_processor
     if not nhs_entity.all_times_valid():
         logger.warning(
-            "Opening Times for NHS are not in expected format or are logically invalid. No open times changes added. "
-            f"OpenTimes={nhs_entity.entity_data.get('OpeningTimes')}"
-        )
+            f"Opening Times for NHS Entity '{nhs_entity.odscode}' were previously found to be invalid or illogical. "
+            "Skipping change."
+            )
         return
 
     # SPECIFIED OPENING TIMES (Comparing a list of SpecifiedOpeningTimes)

--- a/application/event_processor/event_processor.py
+++ b/application/event_processor/event_processor.py
@@ -17,7 +17,7 @@ from common.middlewares import set_correlation_id, unhandled_exception_logging
 from common.utilities import extract_body, get_sequence_number
 from dos import VALID_SERVICE_TYPES, VALID_STATUS_ID, DoSService, get_matching_dos_services, disconnect_dos_db
 from nhs import NHSEntity
-from reporting import log_unmatched_nhsuk_pharmacies, report_closed_or_hidden_services
+from reporting import log_invalid_open_times, log_unmatched_nhsuk_pharmacies, report_closed_or_hidden_services
 from common.encryption import initialise_encryption_client
 
 
@@ -223,6 +223,9 @@ def lambda_handler(event: SQSEvent, context: LambdaContext, metrics) -> None:
         if nhs_entity.is_status_hidden_or_closed():
             report_closed_or_hidden_services(nhs_entity, matching_services)
             return
+
+        if not nhs_entity.all_times_valid():
+            log_invalid_open_times(nhs_entity, matching_services)
 
         event_processor.get_change_requests()
 

--- a/application/event_processor/reporting.py
+++ b/application/event_processor/reporting.py
@@ -99,7 +99,7 @@ def log_invalid_open_times(nhs_entity: NHSEntity, matching_services: List[DoSSer
         matching_services (List[DoSService]): The list of DoS matching services
     """
     logger.warning(
-        f"NHS Entity '{nhs_entity.odscode}' has an misformatted or illogical set of opening times.",
+        f"NHS Entity '{nhs_entity.odscode}' has a misformatted or illogical set of opening times.",
         extra={
             "report_key": INVALID_OPEN_TIMES_REPORT_ID,
             "nhsuk_odscode": nhs_entity.odscode,

--- a/application/event_processor/reporting.py
+++ b/application/event_processor/reporting.py
@@ -104,7 +104,7 @@ def log_invalid_open_times(nhs_entity: NHSEntity, matching_services: List[DoSSer
             "report_key": INVALID_OPEN_TIMES_REPORT_ID,
             "nhsuk_odscode": nhs_entity.odscode,
             "nhsuk_organisation_name": nhs_entity.org_name,
-            "nhsuk_open_times_payload": json.dumps(nhs_entity.entity_data("OpeningTimes")),
+            "nhsuk_open_times_payload": json.dumps(nhs_entity.entity_data["OpeningTimes"]),
             "dos_services": ", ".join(str(service.uid) for service in matching_services)
         }
     )

--- a/application/event_processor/reporting.py
+++ b/application/event_processor/reporting.py
@@ -1,4 +1,5 @@
 from typing import List
+import json
 
 from aws_lambda_powertools.logging.logger import Logger
 
@@ -8,6 +9,8 @@ from nhs import NHSEntity
 HIDDEN_OR_CLOSED_REPORT_ID = "HIDDEN_OR_CLOSED"
 UN_MATCHED_PHARMACY_REPORT_ID = "UN_MATCHED_PHARMACY"
 INVALID_POSTCODE_REPORT_ID = "INVALID_POSTCODE"
+INVALID_OPEN_TIMES_REPORT_ID = "INVALID_OPEN_TIMES"
+
 
 logger = Logger(child=True)
 
@@ -85,4 +88,23 @@ def log_invalid_nhsuk_pharmacy_postcode(nhs_entity: NHSEntity, dos_service: DoSS
             "validation_error_reason": "Postcode not valid/found on DoS",
             "dos_service": dos_service.uid,
         },
+    )
+
+
+def log_invalid_open_times(nhs_entity: NHSEntity, matching_services: List[DoSService]) -> None:
+    """Report invalid open times for nhs entity
+
+    Args:
+        nhs_entity (NHSEntity): The NHS entity to report
+        matching_services (List[DoSService]): The list of DoS matching services
+    """
+    logger.warning(
+        f"NHS Entity '{nhs_entity.odscode}' has an misformatted or illogical set of opening times.",
+        extra={
+            "report_key": INVALID_OPEN_TIMES_REPORT_ID,
+            "nhsuk_odscode": nhs_entity.odscode,
+            "nhsuk_organisation_name": nhs_entity.org_name,
+            "nhsuk_open_times_payload": json.dumps(nhs_entity.entity_data("OpeningTimes")),
+            "dos_services": ", ".join(str(service.uid) for service in matching_services)
+        }
     )

--- a/application/event_processor/tests/test_reporting.py
+++ b/application/event_processor/tests/test_reporting.py
@@ -1,9 +1,12 @@
 from unittest.mock import patch
+import json
 
 from aws_lambda_powertools import Logger
 from ..dos import VALID_STATUS_ID
 from ..nhs import NHSEntity
 from ..reporting import (
+    INVALID_OPEN_TIMES_REPORT_ID,
+    log_invalid_open_times,
     report_closed_or_hidden_services,
     log_unmatched_nhsuk_pharmacies,
     log_invalid_nhsuk_pharmacy_postcode,
@@ -120,5 +123,46 @@ def test_log_invalid_nhsuk_pharmacy_postcode(mock_logger):
             "nhsuk_county": nhs_entity.county,
             "validation_error_reason": "Postcode not valid/found on DoS",
             "dos_service": dos_service.uid,
+        },
+    )
+
+
+@patch.object(Logger, "warning")
+def test_log_invalid_open_times(mock_logger):
+    # Arrange
+    opening_times = [
+        {
+            "Weekday": "Monday",
+            "Times": "09:00-13:00",
+            "OpeningTimeType": "General",
+            "AdditionalOpeningDate": "",
+            "IsOpen": True
+        },
+        {
+            "Weekday": "Monday",
+            "Times": "12:00-17:30",
+            "OpeningTimeType": "General",
+            "AdditionalOpeningDate": "",
+            "IsOpen": True
+        }
+    ]
+    nhs_entity = NHSEntity({
+        "OpeningTimes": opening_times
+    })
+    nhs_entity.odscode = "SLC4X"
+    nhs_entity.org_name = "OrganisationName"
+
+    dos_services = [dummy_dos_service() for i in range(3)]
+    # Act
+    log_invalid_open_times(nhs_entity, dos_services)
+    # Assert
+    mock_logger.assert_called_with(
+        f"NHS Entity '{nhs_entity.odscode}' has an misformatted or illogical set of opening times.",
+        extra={
+            "report_key": INVALID_OPEN_TIMES_REPORT_ID,
+            "nhsuk_odscode": nhs_entity.odscode,
+            "nhsuk_organisation_name": nhs_entity.org_name,
+            "nhsuk_open_times_payload": json.dumps(opening_times),
+            "dos_services": ", ".join(str(service.uid) for service in dos_services)
         },
     )

--- a/application/event_processor/tests/test_reporting.py
+++ b/application/event_processor/tests/test_reporting.py
@@ -157,7 +157,7 @@ def test_log_invalid_open_times(mock_logger):
     log_invalid_open_times(nhs_entity, dos_services)
     # Assert
     mock_logger.assert_called_with(
-        f"NHS Entity '{nhs_entity.odscode}' has an misformatted or illogical set of opening times.",
+        f"NHS Entity '{nhs_entity.odscode}' has a misformatted or illogical set of opening times.",
         extra={
             "report_key": INVALID_OPEN_TIMES_REPORT_ID,
             "nhsuk_odscode": nhs_entity.odscode,


### PR DESCRIPTION
## Link to JIRA Ticket

- https://nhsd-jira.digital.nhs.uk/browse/DI-311

## Description

Added report logging to splunk for invalid opening times.

### Noteworthy Changes

- Initial check of invalid opening times for NHS Entity object for case of logging (subsequent checks used to skip adding to change req)
- Unit tests to run on scenario of invalid opening times entered.

## Type of change

Delete not appropriate

- New feature (non-breaking change which adds functionality)

## Testing

Please tick the testing that has been completed

- [x] Unit tests
- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
