### PR TITLE
DI-314 Added new scenario to check additional DLQ logs

### DIFF
--- a/test/integration/features/parent_features.feature
+++ b/test/integration/features/parent_features.feature
@@ -117,6 +117,13 @@ Feature: DOS INTEGRATION E2E TESTS
     And the DLQ logs the error for Splunk
     And the "eb_dlq" logs show status code "400"
 
+@complete @dev
+  Scenario: DLQ logs show "message abandoned" error_msg
+    Given a Changed Event is valid
+    And the correlation-id is "Bad Request"
+    When the Changed Event is sent for processing with "valid" api key
+    Then the "eb_dlq" logs show error message "Message Abandoned:"
+
 
 @complete @dev
   Scenario: All data required in the Opening times exception report is identifiable in the logs

--- a/test/integration/steps/test_parent_steps.py
+++ b/test/integration/steps/test_parent_steps.py
@@ -368,6 +368,16 @@ def lambda_status_code_check(context, lambda_name, status_code):
     assert logs != [], "ERROR!!.. expected DLQ exception logs not found."
 
 
+@then(parsers.parse('the "{lambda_name}" logs show error message "{error_message}"'))
+def lambda_error_msg_check(context, lambda_name, error_message):
+    query = (
+        f'fields message | sort @timestamp asc | filter correlation_id="{context["correlation_id"]}"'
+        f' | filter error_msg like "{error_message}"'
+    )
+    logs = get_logs(query, lambda_name, context["start_time"])
+    assert logs != [], "ERROR!!.. expected DLQ exception logs not found."
+
+
 @then(parsers.parse('the change request has status code "{status}"'))
 def step_then_should_transform_into(context, status):
     message = context["response"].json


### PR DESCRIPTION
## Link to JIRA Ticket

https://nhsd-jira.digital.nhs.uk/browse/DI-314

## Description

This change is the addition of a single assertion step to check the error_msg field contents in the eventbridge dlq logs. The phrasing uses a variable, so it could feasibly check for an error_msg field in any log in future test cases.
Worth noting that this only tests the second DLQ. The first does not have the ability to force an error, so that is not covered in the integration test.

### Noteworthy Changes

- These are changes the reviewer should look out for

## Type of change

- New integration test step and feature

## Testing

Please tick the testing that has been completed

- [ ] Unit tests
- [x] Integration tests

## Developer Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the [code formatting checks](../README.md#code-quality)
- [x] I have run the [code quality checks](../README.md#code-quality)
- [x] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [x] I can confirm the changes have been tested or approved by a tester
- [x] I can confirm no remaining infrastructure is left over from this branch
