### PR TITLE
Fix integration test dos address error

### DIFF
--- a/application/test_db_checker_handler/test_db_checker_handler.py
+++ b/application/test_db_checker_handler/test_db_checker_handler.py
@@ -38,7 +38,7 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> str:
     elif request["type"] == "get_single_service_odscode":
         query = (
             f"SELECT LEFT(odscode,5) FROM services WHERE typeid IN {tuple(VALID_SERVICE_TYPES)} "
-            f"AND statusid = {VALID_STATUS_ID} AND odscode IS NOT NULL "
+            f"AND statusid = {VALID_STATUS_ID} AND odscode IS NOT NULL AND RIGHT(address, 1) != '$' "
             "AND LENGTH(LEFT(odscode,5)) = 5 GROUP BY LEFT(odscode,5) HAVING COUNT(LEFT(odscode,5)) = 1"
         )
         result = run_query(query, None)

--- a/application/test_db_checker_handler/tests/test_test_db_checker_handler.py
+++ b/application/test_db_checker_handler/tests/test_test_db_checker_handler.py
@@ -47,8 +47,8 @@ def test_type_get_single_service_odscode(mock_run_query, lambda_context):
     # Assert
     mock_run_query.assert_called_once_with(
         "SELECT LEFT(odscode,5) FROM services WHERE typeid IN (131, 132, 134, 137, 13) "
-        "AND statusid = 1 AND odscode IS NOT NULL AND LENGTH(LEFT(odscode,5)) = 5 GROUP BY LEFT(odscode,5) "
-        "HAVING COUNT(LEFT(odscode,5)) = 1",
+        "AND statusid = 1 AND odscode IS NOT NULL AND RIGHT(address, 1) != '$' AND LENGTH(LEFT(odscode,5)) = 5 "
+        "GROUP BY LEFT(odscode,5) HAVING COUNT(LEFT(odscode,5)) = 1",
         None,
     )
     assert response == '["ODS12", "ODS11"]'

--- a/infrastructure/stacks/development-pipeline/integration-tests-buildspec.yml
+++ b/infrastructure/stacks/development-pipeline/integration-tests-buildspec.yml
@@ -52,7 +52,7 @@ phases:
 reports: #New
   PytestIntegrationReport: # CodeBuild will create a report group called "PytestIntegrationReport".
     files: #Store all of the files
-      - '**/*'
+      - 'testresults.json'
     base-directory: $CODEBUILD_SRC_DIR/test/integration
     discard-paths: yes
     file-format: CUCUMBERJSON

--- a/test/integration/steps/utilities/events.py
+++ b/test/integration/steps/utilities/events.py
@@ -96,10 +96,6 @@ def build_same_as_dos_change_event():
         change_event[address_keys[counter]] = address_part
         counter += 1
 
-    if demographics_data["address"][-1] == "$":
-        print("Address ends with $ so retrying")
-        return build_same_as_dos_change_event()  # Recursive call
-
     standard_opening_times = get_change_event_standard_opening_times(demographics_data["id"])
     change_event["OpeningTimes"] = []
     for day in standard_opening_times:

--- a/test/integration/steps/utilities/events.py
+++ b/test/integration/steps/utilities/events.py
@@ -80,7 +80,7 @@ def build_same_as_dos_change_event():
     # TODO Refactor into change event class
     change_event = create_change_event()
     change_event["ODSCode"] = get_single_service_odscode()
-    print(f"New selected ODSCode: {change_event['ODSCode']}")
+    print(f"Latest selected ODSCode: {change_event['ODSCode']}")
     demographics_data = get_change_event_demographics(change_event["ODSCode"])
     change_event["OrganisationName"] = demographics_data["publicname"]
     change_event["Postcode"] = demographics_data["postcode"]
@@ -95,6 +95,10 @@ def build_same_as_dos_change_event():
     for address_part in address_parts:
         change_event[address_keys[counter]] = address_part
         counter += 1
+
+    if demographics_data["address"][-1] == "$":
+        print("Address ends with $ so retrying")
+        return build_same_as_dos_change_event()  # Recursive call
 
     standard_opening_times = get_change_event_standard_opening_times(demographics_data["id"])
     change_event["OpeningTimes"] = []


### PR DESCRIPTION
This PR removes a use case that can't be replicated where the DoS Address ends in a `$` and fixes a test report error