### PR TITLE
DI-331 Chaos Test Circuit Breaker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -602,16 +602,16 @@ send-performance-dashboard-slack-message:
 # -----------------------------
 # Chaos Testing
 
-setup-no-dos-chaos-test: # Setup chaos test environment
+setup-no-dos-chaos-test: # Setup chaos test environment (Sets DoS API Gateway mock to be unavailable) - mandatory: PROFILE; optional: ENVIRONMENT
 	make terraform-destroy-auto-approve STACKS="dos-api-gateway-mock" OPTS="-target aws_route53_record.uec_dos_integration_api_endpoint"
 
 restore-from-no-dos-chaos-test: # Restore from chaos test environment
 	make terraform-apply-auto-approve STACKS="dos-api-gateway-mock" OPTS="-target aws_route53_record.uec_dos_integration_api_endpoint"
 
-setup-dos-chaos-test: # Setup chaos test environment
+setup-circuit-breaker-chaos-test: # Setup chaos test environment (Sets DoS API Gateway mock to return 500 errors) - mandatory: PROFILE; optional: ENVIRONMENT
 	make mock-dos-api-gateway-deployment TF_VAR_chaos_mode="true"
 
-restore-from-dos-chaos-test: # Restore from chaos test environment
+restore-from-circuit-breaker-chaos-test: # Restore from chaos test environment
 	make mock-dos-api-gateway-deployment
 
 # -----------------------------

--- a/Makefile
+++ b/Makefile
@@ -522,7 +522,7 @@ load-test: # Create change events for load performance testing - mandatory: PROF
 	make -s docker-run-tools \
 		IMAGE=$$(make _docker-get-reg)/tester \
 		CMD="python -m locust -f load_test_locustfile.py --headless \
-			--users 50 --spawn-rate 2 --run-time 40m --stop-timeout 5 --exit-code-on-error 0 \
+			--users 50 --spawn-rate 2 --run-time 30m --stop-timeout 5	 --exit-code-on-error 0 \
 			-H https://$(DOS_INTEGRATION_URL) \
 			--csv=results/$(START_TIME)_create_change_events" \
 		DIR=./test/performance/create_change_events \

--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,8 @@ clean: # Runs whole project clean
 		test-db-checker-handler-clean \
 		tester-clean \
 		authoriser-clean \
-		dos-api-gateway-clean
+		dos-api-gateway-clean \
+		performance-test-clean
 
 # ==============================================================================
 # Mocks Setup
@@ -521,7 +522,7 @@ load-test: # Create change events for load performance testing - mandatory: PROF
 	make -s docker-run-tools \
 		IMAGE=$$(make _docker-get-reg)/tester \
 		CMD="python -m locust -f load_test_locustfile.py --headless \
-			--users 50 --spawn-rate 2 --run-time 30m --stop-timeout 5	 --exit-code-on-error 0 \
+			--users 50 --spawn-rate 2 --run-time 40m --stop-timeout 5 --exit-code-on-error 0 \
 			-H https://$(DOS_INTEGRATION_URL) \
 			--csv=results/$(START_TIME)_create_change_events" \
 		DIR=./test/performance/create_change_events \
@@ -605,13 +606,13 @@ send-performance-dashboard-slack-message:
 setup-no-dos-chaos-test: # Setup chaos test environment (Sets DoS API Gateway mock to be unavailable) - mandatory: PROFILE; optional: ENVIRONMENT
 	make terraform-destroy-auto-approve STACKS="dos-api-gateway-mock" OPTS="-target aws_route53_record.uec_dos_integration_api_endpoint"
 
-restore-from-no-dos-chaos-test: # Restore from chaos test environment
-	make terraform-apply-auto-approve STACKS="dos-api-gateway-mock" OPTS="-target aws_route53_record.uec_dos_integration_api_endpoint"
+restore-from-no-dos-chaos-test: # Restore from chaos test environment - mandatory: PROFILE; optional: ENVIRONMENT
+	make mock-dos-api-gateway-deployment
 
 setup-circuit-breaker-chaos-test: # Setup chaos test environment (Sets DoS API Gateway mock to return 500 errors) - mandatory: PROFILE; optional: ENVIRONMENT
 	make mock-dos-api-gateway-deployment TF_VAR_chaos_mode="true"
 
-restore-from-circuit-breaker-chaos-test: # Restore from chaos test environment
+restore-from-circuit-breaker-chaos-test: # Restore from chaos test environment - mandatory: PROFILE; optional: ENVIRONMENT
 	make mock-dos-api-gateway-deployment
 
 # -----------------------------

--- a/Makefile
+++ b/Makefile
@@ -597,6 +597,15 @@ send-performance-dashboard-slack-message:
 	}'
 
 # -----------------------------
+# Chaos Testing
+
+setup-chaos-test: # Setup chaos test environment
+	make terraform-destroy-auto-approve STACKS="dos-api-gateway-mock" OPTS="-target aws_route53_record.uec_dos_integration_api_endpoint"
+
+restore-from-chaos-test: # Restore from chaos test environment
+	make terraform-apply-auto-approve STACKS="dos-api-gateway-mock" OPTS="-target aws_route53_record.uec_dos_integration_api_endpoint"
+
+# -----------------------------
 # Other
 
 update-all-ip-allowlists: # Update your IP address in AWS secrets manager to acesss non-prod environments - mandatory: PROFILE, ENVIRONMENT, USERNAME

--- a/application/dos_api_gateway/dos_api_gateway.py
+++ b/application/dos_api_gateway/dos_api_gateway.py
@@ -28,8 +28,9 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> Dict[str, A
         correlation_id = change_request["reference"]
         logger.set_correlation_id(correlation_id)
         logger.info("MOCK DoS API Gateway - Change request received", extra={"change_request": event})
-    print(getenv("CHAOS_MODE"))
+
     if getenv("CHAOS_MODE") == "true":
+        logger.warning("CHAOS MODE ENABLED - Returning a 500 response")
         return {"statusCode": 500, "body": "Chaos mode is enabled"}
 
     if "bad request" in correlation_id.lower():

--- a/application/dos_api_gateway/dos_api_gateway.py
+++ b/application/dos_api_gateway/dos_api_gateway.py
@@ -19,23 +19,24 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> Dict[str, A
     Returns:
         dict: Response to change request
     """
-    logger.debug("Event Received", extra={"event": event})
+    logger.info("Event Received", extra={"event": event})
     change_request = loads(event["body"])
     sleep(1.7)
     if change_request == {}:
         logger.warning("Empty change request received, likely a health check")
-    else:
-        correlation_id = change_request["reference"]
-        logger.set_correlation_id(correlation_id)
-        logger.info("MOCK DoS API Gateway - Change request received", extra={"change_request": event})
+        return {"statusCode": 400, "body": "Change Request is empty"}
+
+    correlation_id = change_request["reference"]
+    logger.set_correlation_id(correlation_id)
+    logger.info("MOCK DoS API Gateway - Change request received", extra={"change_request": event})
+
+    if "bad request" in correlation_id.lower():
+        logger.warning("MOCK DoS API Gateway - Returning Fake Bad Request", extra={"change_request": event})
+        return {"statusCode": 400, "body": "Fake Bad Request trigged by correlation-id"}
 
     if getenv("CHAOS_MODE") == "true":
         logger.warning("CHAOS MODE ENABLED - Returning a 500 response")
         return {"statusCode": 500, "body": "Chaos mode is enabled"}
-
-    if "bad request" in correlation_id.lower():
-        logger.info("Bad Request  - MOCK DoS API Gateway - Returning Fake Bad Request", extra={"change_request": event})
-        return {"statusCode": 400, "body": "Fake Bad Request trigged by correlation-id"}
 
     change_request_response = {"dosChanges": []}
 

--- a/application/event_sender/change_request_logger.py
+++ b/application/event_sender/change_request_logger.py
@@ -28,7 +28,7 @@ class ChangeRequestLogger:
             response_data = loads(response.text)
             changes = response_data.get("dosChanges")
             if changes is None or len(changes) == 0:
-                logger.warning("Change request generated no changes")
+                logger.warning("Change request generated no changes within DoS")
             extra = {
                 "state": "Success",
                 "response_status_code": response.status_code,

--- a/application/event_sender/event_sender.py
+++ b/application/event_sender/event_sender.py
@@ -105,3 +105,4 @@ def lambda_handler(event: ChangeRequestQueueItem, context: LambdaContext, metric
             metrics.set_property("StatusCode", response.status_code)
             metrics.set_property("message", f"DoS API failed with status code {response.status_code}")
             metrics.put_metric("DoSApiFail", 1, "Count")
+    return {"statusCode": response.status_code, "body": response.text}

--- a/application/event_sender/tests/test_change_request_logger.py
+++ b/application/event_sender/tests/test_change_request_logger.py
@@ -95,7 +95,7 @@ class TestChangeRequestLogger:
         change_request_logger.log_change_request_response(change_request_response)
         # Assert
         info_logger_mock.assert_called_with("Successfully send change request to DoS", extra=info_logger_expected)
-        warn_logger_mock.assert_called_with("Change request generated no changes")
+        warn_logger_mock.assert_called_with("Change request generated no changes within DoS")
 
     @patch.object(Logger, "info")
     @patch.object(Logger, "warning")
@@ -119,7 +119,7 @@ class TestChangeRequestLogger:
         change_request_logger.log_change_request_response(change_request_response)
         # Assert
         info_logger_mock.assert_called_with("Successfully send change request to DoS", extra=info_logger_expected)
-        warn_logger_mock.assert_called_with("Change request generated no changes")
+        warn_logger_mock.assert_called_with("Change request generated no changes within DoS")
 
     @patch.object(Logger, "exception")
     def test_log_change_request_exception(self, exception_logger_mock):

--- a/application/event_sender/tests/test_event_sender.py
+++ b/application/event_sender/tests/test_event_sender.py
@@ -85,8 +85,10 @@ def test_lambda_handler_dos_api_success(
     environ["ENV"] = "test"
     environ["DOS_API_GATEWAY_REQUEST_TIMEOUT"] = "1"
     # Act
-    lambda_handler(EVENT, lambda_context)
+    response = lambda_handler(EVENT, lambda_context)
     # Assert
+    assert response["statusCode"] == 201
+    assert response["body"] == "success"
     mock_client.assert_called_with("sqs")
     mock_change_request.assert_called_once_with(CHANGE_REQUEST)
     mock_instance.post_change_request.assert_called_once_with()
@@ -126,8 +128,10 @@ def test_lambda_handler_dos_api_fail(
     environ["ENV"] = "test"
     environ["CIRCUIT"] = "testcircuit"
     # Act
-    lambda_handler(EVENT, lambda_context)
+    response = lambda_handler(EVENT, lambda_context)
     # Assert
+    assert response["statusCode"] == 201
+    assert response["body"] == "success"
     mock_client.assert_called_with("sqs")
     mock_change_request.assert_called_once_with(CHANGE_REQUEST)
     mock_change_request().post_change_request.assert_called_once_with()
@@ -157,8 +161,10 @@ def test_lambda_handler_health_check(
     HEALTH_EVENT = EVENT.copy()
     HEALTH_EVENT["is_health_check"] = True
     # Act
-    lambda_handler(HEALTH_EVENT, lambda_context)
+    response = lambda_handler(EVENT, lambda_context)
     # Assert
+    assert response["statusCode"] == 201
+    assert response["body"] == "success"
     mock_client.assert_called_with("sqs")
     mock_instance.post_change_request.assert_called_once()
     mock_put_metric.assert_not_called()
@@ -197,8 +203,10 @@ def test_lambda_handler_non_recoverable_error(
     environ["CR_DLQ_URL"] = dlq_queue_name
     environ["CR_QUEUE_URL"] = incoming_queue_url
     # Act
-    lambda_handler(EVENT, lambda_context)
+    response = lambda_handler(EVENT, lambda_context)
     # Assert
+    assert response["statusCode"] == 201
+    assert response["body"] == "success"
     mock_client.assert_called_with("sqs")
     mock_change_request.assert_called_once_with(CHANGE_REQUEST)
     mock_change_request().post_change_request.assert_called_once_with()

--- a/infrastructure/stacks/cloudwatch-dashboard/main.tf
+++ b/infrastructure/stacks/cloudwatch-dashboard/main.tf
@@ -260,8 +260,8 @@ resource "aws_cloudwatch_dashboard" "cloudwatch_dashboard" {
         },
         {
             "type": "metric",
-            "x": 0,
-            "y": 24,
+            "x": 18,
+            "y": 0,
             "width": 6,
             "height": 6,
             "properties": {
@@ -273,6 +273,23 @@ resource "aws_cloudwatch_dashboard" "cloudwatch_dashboard" {
                 "region": "${var.aws_region}",
                 "period": 300,
                 "stat": "Sum"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 18,
+            "y": 0,
+            "width": 6,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "UEC-DOS-INT", "DoSApiUnavailable", "ENV", "${var.environment}" ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.aws_region}",
+                "period": 300,
+                "stat": "Average"
             }
         }
     ]

--- a/infrastructure/stacks/dos-api-gateway-mock/dos-api-gateway-mock-lambda.tf
+++ b/infrastructure/stacks/dos-api-gateway-mock/dos-api-gateway-mock-lambda.tf
@@ -88,6 +88,7 @@ resource "aws_lambda_function" "dos_api_gateway_lambda" {
   environment {
     variables = {
       "POWERTOOLS_SERVICE_NAME" = var.powertools_service_name
+      "CHAOS_MODE"              = var.chaos_mode
     }
   }
 }

--- a/infrastructure/stacks/dos-api-gateway-mock/variables.tf
+++ b/infrastructure/stacks/dos-api-gateway-mock/variables.tf
@@ -104,6 +104,11 @@ variable "powertools_service_name" {
   description = "The name of the aws powertools service"
 }
 
+variable "chaos_mode" {
+  description = "Should Chaos mode be enabled?"
+  default     = false
+}
+
 # ############################
 # # ROUTE53
 # ############################

--- a/infrastructure/stacks/lambda-iam-roles/main.tf
+++ b/infrastructure/stacks/lambda-iam-roles/main.tf
@@ -169,6 +169,26 @@ resource "aws_iam_role_policy" "event_sender_policy" {
     {
       "Effect": "Allow",
       "Action": [
+        "dynamodb:BatchGetItem",
+        "dynamodb:GetItem",
+        "dynamodb:Query",
+        "dynamodb:Scan",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:PutItem",
+        "dynamodb:UpdateItem"
+      ],
+      "Resource":"arn:aws:dynamodb:${var.aws_region}:${var.aws_account_id}:table/${var.change_events_table_name}"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:Query"
+      ],
+      "Resource":"arn:aws:dynamodb:${var.aws_region}:${var.aws_account_id}:table/${var.change_events_table_name}/index/gsi_ods_sequence"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
         "logs:CreateLogGroup",
         "logs:CreateLogStream",
         "logs:PutLogEvents",


### PR DESCRIPTION
## Link to JIRA Ticket

- https://nhsd-jira.digital.nhs.uk/browse/DI-331

## Description

This PR is to add tools to chaos test the DI application including turning off the DoS API Gateway Mock.

### Noteworthy Changes

- Improved logging around health checks in the event sender
- Add dynamodb IAM permissions to event sender
- Fixed a bug if the DoS API Gateway doesn't exist (service unavailable)

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Testing

Please tick the testing that has been completed

- [x] Unit tests
- [x] Integration tests

## Developer Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the [code formatting checks](../README.md#code-quality)
- [x] I have run the [code quality checks](../README.md#code-quality)
- [x] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [x] Unit test code coverage is at or above 80%
- [x] New and existing unit tests pass locally with my changes
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
