### PR TITLE
DI-346 Create Change Request(CR) when address lines are same but not the postcode

### DIFF
--- a/application/common/opening_times.py
+++ b/application/common/opening_times.py
@@ -125,7 +125,6 @@ class OpenPeriod:
 
 
 class SpecifiedOpeningTime:
-
     def __init__(self, open_periods: List[OpenPeriod], specified_date: date, is_open: bool = True):
         assert isinstance(specified_date, date)
         self.open_periods = open_periods

--- a/application/common/tests/test_dos.py
+++ b/application/common/tests/test_dos.py
@@ -161,7 +161,7 @@ def test_get_specified_opening_times_from_db_times_returned(mock_query_dos_db):
             "<SpecifiedOpenTime: 27-05-2019 open=True [08:00:00-20:00:00]>",
             "<SpecifiedOpenTime: 26-08-2019 open=True [08:00:00-20:00:00, 21:00:00-22:00:00]>",
             "<SpecifiedOpenTime: 20-09-2019 open=False []>",
-            "<SpecifiedOpenTime: 21-09-2019 open=False []>"
+            "<SpecifiedOpenTime: 21-09-2019 open=False []>",
         ]
     )
     # Act

--- a/application/event_processor/changes.py
+++ b/application/event_processor/changes.py
@@ -27,8 +27,7 @@ def get_changes(dos_service: DoSService, nhs_entity: NHSEntity) -> Dict[str, str
     update_changes(changes, WEBSITE_CHANGE_KEY, dos_service.web, nhs_entity.website)
     update_changes(changes, PHONE_CHANGE_KEY, dos_service.publicphone, nhs_entity.phone)
     update_changes(changes, PUBLICNAME_CHANGE_KEY, dos_service.publicname, nhs_entity.org_name)
-    update_changes_with_address(changes, dos_service, nhs_entity)
-    update_changes_with_postcode(changes, dos_service, nhs_entity)
+    update_changes_with_address_and_postcode(changes, dos_service, nhs_entity)
     update_changes_with_opening_times(changes, dos_service, nhs_entity)
     return changes
 
@@ -112,11 +111,18 @@ def update_changes_with_opening_times(changes: dict, dos_service: DoSService, nh
         changes[OPENING_DAYS_KEY] = nhs_std_open_dates.export_cr_format()
 
 
-def update_changes_with_postcode(changes: dict, dos_service: DoSService, nhs_entity: NHSEntity) -> None:
+def update_changes_with_address_and_postcode(changes: dict, dos_service: DoSService, nhs_entity: NHSEntity) -> None:
+
+    nhs_uk_address_string = "$".join(nhs_entity.address_lines)
+    dos_address = dos_service.address
+    is_address_same = True
+    if dos_address != nhs_uk_address_string:
+        is_address_same = False
+        logger.debug(f"Address is not equal, {dos_address=} != {nhs_uk_address_string=}")
+        changes[ADDRESS_CHANGE_KEY] = {ADDRESS_LINES_KEY: nhs_entity.address_lines}
 
     dos_postcode = dos_service.normal_postcode()
     nhs_postcode = nhs_entity.normal_postcode()
-
     if dos_postcode != nhs_postcode:
         logger.debug(f"Postcode is not equal, {dos_postcode=} != {nhs_postcode=}")
 
@@ -127,4 +133,7 @@ def update_changes_with_postcode(changes: dict, dos_service: DoSService, nhs_ent
                 del changes[ADDRESS_CHANGE_KEY]
                 logger.info("Deleted address change as postcode is invalid")
         else:
+            if is_address_same:
+                changes[ADDRESS_CHANGE_KEY] = {ADDRESS_LINES_KEY: nhs_entity.address_lines}
+                logger.debug(f"Address is equal but Postcode is not equal, {dos_postcode=} != {nhs_postcode=}")
             changes[ADDRESS_CHANGE_KEY][POSTCODE_CHANGE_KEY] = valid_dos_postcode


### PR DESCRIPTION
## Link to JIRA Ticket

-https://nhsd-jira.digital.nhs.uk/browse/DI-346

## Description

Not creating an address change request (CR) when the address is same but not the postcode.

### Noteworthy Changes
- Removed update_changes_with_address method in changes.py 
- Rename update_changes_with_postcode to update_changes_with_address_and_postcode 
- Combined both the fuctionality in one method and updated the unit tests.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Testing

Please tick the testing that has been completed

- [x] Unit tests
- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
