### PR TITLE
DI-348 Refractor log chain to catch known errors

### DIFF
--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -3,6 +3,9 @@ from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
 from aws_lambda_powertools.utilities.data_classes import SQSEvent
 from aws_lambda_powertools.utilities.typing import LambdaContext
 
+from event_processor.change_event_exceptions import ValidationException
+
+
 logger = Logger(child=True)
 
 
@@ -11,6 +14,9 @@ def unhandled_exception_logging(handler, event, context: LambdaContext):
     try:
         response = handler(event, context)
         return response
+    except ValidationException as err:
+        logger.exception("Validation Error", extra={"error": err, "event": event})
+        return
     except BaseException as err:
         logger.exception("Something went wrong", extra={"error": err, "event": event})
         raise

--- a/application/event_processor/change_event_validation.py
+++ b/application/event_processor/change_event_validation.py
@@ -21,8 +21,7 @@ def validate_event(event: Dict[str, Any]) -> None:
     try:
         validate(event=event, schema=INPUT_SCHEMA)
     except SchemaValidationError as exception:
-        logger.error(f"Input schema validation error|{str(exception)}", extra={"event": event})
-        raise ValidationException()
+        raise ValidationException(str(exception))
     check_org_type_id(org_type_id=event["OrganisationTypeId"])
     check_org_sub_type(org_sub_type=event["OrganisationSubType"])
     check_ods_code_length(odscode=event["ODSCode"])

--- a/application/event_processor/change_event_validation.py
+++ b/application/event_processor/change_event_validation.py
@@ -21,7 +21,7 @@ def validate_event(event: Dict[str, Any]) -> None:
     try:
         validate(event=event, schema=INPUT_SCHEMA)
     except SchemaValidationError as exception:
-        raise ValidationException(str(exception))
+        raise ValidationException(exception)
     check_org_type_id(org_type_id=event["OrganisationTypeId"])
     check_org_sub_type(org_sub_type=event["OrganisationSubType"])
     check_ods_code_length(odscode=event["ODSCode"])

--- a/application/event_processor/change_event_validation.py
+++ b/application/event_processor/change_event_validation.py
@@ -21,8 +21,8 @@ def validate_event(event: Dict[str, Any]) -> None:
     try:
         validate(event=event, schema=INPUT_SCHEMA)
     except SchemaValidationError as exception:
-        logger.exception(f"Input schema validation error|{str(exception)}", extra={"event": event})
-        raise ValidationException("Change Event malformed, validation failed")
+        logger.error(f"Input schema validation error|{str(exception)}", extra={"event": event})
+        raise ValidationException()
     check_org_type_id(org_type_id=event["OrganisationTypeId"])
     check_org_sub_type(org_sub_type=event["OrganisationSubType"])
     check_ods_code_length(odscode=event["ODSCode"])

--- a/application/event_processor/event_processor.py
+++ b/application/event_processor/event_processor.py
@@ -9,7 +9,6 @@ from aws_lambda_powertools import Logger, Tracer
 from aws_lambda_powertools.utilities.data_classes import SQSEvent, event_source
 from aws_lambda_powertools.utilities.typing.lambda_context import LambdaContext
 from boto3 import client
-from change_event_exceptions import ValidationException
 from change_event_validation import validate_event
 from change_request import ChangeRequest
 from changes import get_changes
@@ -248,10 +247,6 @@ def lambda_handler(event: SQSEvent, context: LambdaContext, metrics) -> None:
             log_invalid_open_times(nhs_entity, matching_services)
 
         event_processor.get_change_requests()
-
-    except ValidationException as err:
-        logger.exception("Validation Error", extra={"error": err})
-        return
     finally:
         disconnect_dos_db()
 

--- a/application/event_processor/event_processor.py
+++ b/application/event_processor/event_processor.py
@@ -250,8 +250,8 @@ def lambda_handler(event: SQSEvent, context: LambdaContext, metrics) -> None:
         event_processor.get_change_requests()
 
     except ValidationException as err:
-        logger.exception("Something went wrong", extra={"error": err})
-        raise
+        logger.exception("Validation Error", extra={"error": err})
+        return
     finally:
         disconnect_dos_db()
 

--- a/application/event_processor/tests/test_event_processor.py
+++ b/application/event_processor/tests/test_event_processor.py
@@ -3,10 +3,9 @@ from json import dumps
 from os import environ
 import hashlib
 from random import choices
-from change_event_exceptions import ValidationException
 from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
 from aws_lambda_powertools import Logger
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 import logging
 
 from pytest import fixture, raises
@@ -540,7 +539,6 @@ def test_lambda_handler_should_throw_exception(
     with caplog.at_level(logging.ERROR):
         lambda_handler(sqs_event, lambda_context)
     assert "Validation Error" in caplog.text
-
     # Clean up
     for env in EXPECTED_ENVIRONMENT_VARIABLES:
         del environ[env]

--- a/application/event_processor/tests/test_event_processor.py
+++ b/application/event_processor/tests/test_event_processor.py
@@ -506,7 +506,9 @@ def test_lambda_handler_invalid_open_times(
 @patch(f"{FILE_PATH}.EventProcessor")
 @patch(f"{FILE_PATH}.NHSEntity")
 @patch(f"{FILE_PATH}.extract_body")
+@patch.object(Logger, "error")
 def test_lambda_handler_should_throw_exception(
+    mock_logger,
     mock_extract_body,
     mock_nhs_entity,
     mock_event_processor,
@@ -536,8 +538,8 @@ def test_lambda_handler_should_throw_exception(
     for env in EXPECTED_ENVIRONMENT_VARIABLES:
         environ[env] = "test"
     # Act
-    with raises(ValidationException):
-        lambda_handler(sqs_event, lambda_context)
+    lambda_handler(sqs_event, lambda_context)
+    mock_logger.assert_called_with("Validation Error", exc_info=True, extra={'error': ValidationException()})
     # Clean up
     for env in EXPECTED_ENVIRONMENT_VARIABLES:
         del environ[env]


### PR DESCRIPTION
## Link to JIRA Ticket

- https://nhsd-jira.digital.nhs.uk/browse/DI-348

## Description

Validation error is only caught on top decorator level and is logged but not raised. This is so it is properly removed from SQS queue and not retried.

## Type of change

Delete not appropriate

- Bug fix (non-breaking change which fixes an issue)

## Testing

Please tick the testing that has been completed

- [ ] Unit tests
- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
