### PR TITLE
Improve lambda logging

### DIFF
--- a/application/common/tests/conftest.py
+++ b/application/common/tests/conftest.py
@@ -1,12 +1,13 @@
-from pytest import fixture
-import boto3
-from moto import mock_dynamodb2
-import os
 import json
+import os
 from random import choices, randint, uniform
+
+import boto3
+from moto import mock_dynamodb
+from pytest import fixture
+
 from ..dos import DoSLocation, DoSService
 from ..opening_times import StandardOpeningTimes
-
 
 std_event_path = "event_processor/tests/STANDARD_EVENT.json"
 
@@ -58,7 +59,7 @@ def aws_credentials():
 
 @fixture
 def dynamodb_client(aws_credentials):
-    with mock_dynamodb2():
+    with mock_dynamodb():
         conn = boto3.client("dynamodb", region_name=os.environ["AWS_REGION"])
         yield conn
 

--- a/application/event_processor/event_processor.py
+++ b/application/event_processor/event_processor.py
@@ -118,7 +118,7 @@ class EventProcessor:
             logger.debug(
                 "CR to send",
                 extra={
-                    "change_request": change_request,
+                    "change_request": change_payload,
                     "entry_id": entry_id,
                     "hashed_payload": f"{len(hashed_payload)} - {hashed_payload}",
                     "message_deduplication_id": message_deduplication_id,
@@ -197,7 +197,7 @@ def lambda_handler(event: SQSEvent, context: LambdaContext, metrics) -> None:
     s, ms = divmod(sqs_timestamp, 1000)
     message_received_pretty = "%s.%03d" % (strftime("%Y-%m-%d %H:%M:%S", gmtime(s)), ms)
     logger.append_keys(message_received=message_received_pretty)
-    logger.info("Change Event received", extra={"event": event})
+    logger.info("Change Event received", extra={"change-event": change_event})
     metrics.set_namespace("UEC-DOS-INT")
     metrics.set_property("level", "INFO")
     metrics.set_property("function_name", context.function_name)


### PR DESCRIPTION
This PR is to fix where objects are logged rather than the data the class holds.

As well I have fixed a deprecation warning in the unit tests