### PR TITLE
DI-375 Modify correlation id character length limit

### DIFF
--- a/test/integration/features/F006_Opening_times.feature
+++ b/test/integration/features/F006_Opening_times.feature
@@ -9,7 +9,7 @@ Feature: F006. Opening times
 
 @complete
   Scenario: F006S002. Confirm actual opening times change for standard date and time is captured by Dos
-    Given a standard opening time Changed Event is valid
+    Given an opened standard opening time Changed Event is valid
     When the Changed Event is sent for processing with "valid" api key
     Then the processed Changed Request is sent to Dos
     And the Changed Request with changed standard day time is captured by Dos
@@ -58,23 +58,22 @@ Feature: F006. Opening times
   Scenario: F006S008. Confirm recently added specified opening date can be removed from Dos
     Given an opened specified opening time Changed Event is valid
     When the Changed Event is sent for processing with "valid" api key
-    Then the processed Changed Request is sent to Dos
-    And the Changed Request with changed specified date and time is captured by Dos
+    Then the Changed Request with changed specified date and time is captured by Dos
     And the Changed Event is replayed with the specified opening date deleted
     And the deleted specified date is confirmed removed from Dos
 
-  @complete
+@complete
   Scenario: F006S009. A recently closed pharmacy on a standard day can be opened
     Given a specific Changed Event is valid
     When the Changed Event is sent for processing with "valid" api key
-    Then the processed Changed Request is sent to Dos
-    And the pharmacy is confirmed "CLOSED" for the standard day in Dos
-    And the Changed Event is replayed with the pharmacy now open
-    And the pharmacy is confirmed "OPEN" for the standard day in Dos
+    Then the pharmacy is confirmed "closed" for the standard day in Dos
+    And the Changed Event is replayed with the pharmacy now "open"
+    And the pharmacy is confirmed "open" for the standard day in Dos
 
+@complete
   Scenario: F006S010. A recently opened pharmacy on a standard day can be closed
-    Given a specific Changed Event is valid
+    Given an opened standard opening time Changed Event is valid
     When the Changed Event is sent for processing with "valid" api key
-    And the pharmacy is confirmed 'open' for the standard day in Dos
-    And the Changed Event is replayed with the pharmacy now 'closed'
-    And the pharmacy is confirmed 'closed' for the standard day in Dos
+    Then the pharmacy is confirmed "open" for the standard day in Dos
+    And the Changed Event is replayed with the pharmacy now "closed"
+    And the pharmacy is confirmed "closed" for the standard day in Dos

--- a/test/integration/steps/test_parent_steps.py
+++ b/test/integration/steps/test_parent_steps.py
@@ -92,7 +92,7 @@ def a_specified_opening_time_change_event_is_valid():
     return context
 
 
-@given("a standard opening time Changed Event is valid", target_fixture="context")
+@given("an opened standard opening time Changed Event is valid", target_fixture="context")
 def a_standard_opening_time_change_event_is_valid():
     closing_time = datetime.datetime.now().time().strftime("%H:%M")
     context = {}
@@ -754,13 +754,21 @@ def specified_date_is_removed_from_dos(context):
     ), f"Error!.. Removed specified date: {removed_date} still exists in Dos"
 
 
-@then("the Changed Event is replayed with the pharmacy now open")
-def event_replayed_with_pharmacy_closed(context, valid_or_invalid):
+@then(parsers.parse('the Changed Event is replayed with the pharmacy now "{open_or_closed}"'))
+def event_replayed_with_pharmacy_closed(context, valid_or_invalid, open_or_closed):
     closing_time = datetime.datetime.now().time().strftime("%H:%M")
-    context["change_event"]["OpeningTimes"][-2]["OpeningTime"] = "00:01"
-    context["change_event"]["OpeningTimes"][-2]["ClosingTime"] = closing_time
-    context["change_event"]["OpeningTimes"][-2]["IsOpen"] = True
-    context["correlation_id"] = f'{context["correlation_id"]}-open-replay'
+    if open_or_closed.upper() == "OPEN":
+        context["change_event"]["OpeningTimes"][-2]["OpeningTime"] = "00:01"
+        context["change_event"]["OpeningTimes"][-2]["ClosingTime"] = closing_time
+        context["change_event"]["OpeningTimes"][-2]["IsOpen"] = True
+        context["correlation_id"] = f'{context["correlation_id"]}_open_replay'
+    elif open_or_closed.upper() == "CLOSED":
+        context["change_event"]["OpeningTimes"][-2]["OpeningTime"] = ""
+        context["change_event"]["OpeningTimes"][-2]["ClosingTime"] = ""
+        context["change_event"]["OpeningTimes"][-2]["IsOpen"] = False
+        context["correlation_id"] = f'{context["correlation_id"]}_closed_replay'
+    else:
+        raise ValueError(f'Invalid status input parameter: "{open_or_closed}"')
     context["response"] = process_payload(
         context["change_event"], valid_or_invalid == "valid", context["correlation_id"]
     )

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -324,7 +324,7 @@ def generate_correlation_id(suffix=None) -> str:
     run_id = getenv("RUN_ID")
     correlation_id = f"{run_id}_{name_no_space}" if suffix is None else f"{run_id}_{suffix}"
     correlation_id = (
-        correlation_id if len(correlation_id) < 100 else correlation_id[:99]
+        correlation_id if len(correlation_id) < 80 else correlation_id[:79]
     )  # DoS API Gateway max reference is 100 characters
     return correlation_id
 


### PR DESCRIPTION
## Link to JIRA Ticket
https://nhsd-jira.digital.nhs.uk/browse/DI-375
-

## Description

Dos API currently has a limit 100 on the number of characters for the Correlation Id when invoked. Modifying the Correlation Id character limit in the Utils file on Test suite will facilitate replaying of Changed Events with additional characters on the correlation Id for specific scenarios.

Affected scenarios: F006S008 & F006S009

### Noteworthy Changes

Added new scenario F006S010
Modified Correlation id to accomodate change event replays.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Testing

- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
