### PR TITLE
DI-405 Fix bug on retrieving pharmacy single service function

### DIFF
--- a/test/integration/features/F001_Valid_Change_Events.feature
+++ b/test/integration/features/F001_Valid_Change_Events.feature
@@ -1,6 +1,6 @@
 Feature: F001. Ensure valid change events are converted and sent to DOS
 
-  @complete @smoke @no_log_searches
+@complete @smoke @no_log_searches
   Scenario: F001S001. A valid change event is processed and accepted by DOS
     Given a Changed Event is valid
     When the Changed Event is sent for processing with "valid" api key
@@ -20,7 +20,7 @@ Feature: F001. Ensure valid change events are converted and sent to DOS
     Then no Changed request is created
     And the Changed Event is stored in dynamo db
 
-  @complete @no_log_searches
+@complete @no_log_searches
   Scenario: F001S004. A valid change event with changed Phone number is processed and captured by DOS
     Given a Changed Event with changed "phone_no" is valid
     When the Changed Event is sent for processing with "valid" api key

--- a/test/integration/features/F004_Error_Handling.feature
+++ b/test/integration/features/F004_Error_Handling.feature
@@ -51,7 +51,7 @@ Feature: F004. Error Handling
     When the Changed Event is sent for processing with sequence id ABCD1
     Then the change request has status code "400"
 
-  @complete @dev @cloudwatch_queries
+@complete @dev @cloudwatch_queries
   Scenario Outline: F004S008. An exception is raised when Sequence number is less than previous
     Given an ODS has an entry in dynamodb
     When the Changed Event is sent for processing with sequence id <seqid>

--- a/test/integration/features/F006_Opening_times.feature
+++ b/test/integration/features/F006_Opening_times.feature
@@ -1,6 +1,6 @@
 Feature: F006. Opening times
 
-  @complete @no_log_searches
+@complete @no_log_searches
   Scenario: F006S001. Confirm actual opening times change for specified date and time is captured by Dos
     Given an opened specified opening time Changed Event is valid
     When the Changed Event is sent for processing with "valid" api key

--- a/test/integration/steps/utilities/events.py
+++ b/test/integration/steps/utilities/events.py
@@ -97,7 +97,7 @@ def build_same_as_dos_change_event(service_type: str):
     # TODO Refactor into change event class
     change_event = create_change_event(service_type)
     if service_type.upper() == "PHARMACY":
-        change_event["ODSCode"] = get_single_service_odscode(PHARMACY_ORG_TYPE_ID)
+        change_event["ODSCode"] = get_single_service_odscode()
         demographics_data = get_change_event_demographics(change_event["ODSCode"], PHARMACY_ORG_TYPE_ID)
     elif service_type.upper() == "DENTIST":
         demographics_data = get_change_event_demographics(change_event["ODSCode"], DENTIST_ORG_TYPE_ID)

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -139,8 +139,8 @@ def get_odscodes_list(lambda_payload: dict) -> list[list[str]]:
     return data
 
 
-def get_single_service_odscode(organisation_type_id: str) -> str:
-    lambda_payload = {"type": "get_single_service_odscode", "organisation_type_id": organisation_type_id}
+def get_single_service_odscode() -> str:
+    lambda_payload = {"type": "get_single_pharmacy_service_odscode"}
     response = invoke_test_db_checker_handler_lambda(lambda_payload)
     data = loads(response)
     data = literal_eval(data)


### PR DESCRIPTION
## Link to JIRA Ticket

https://nhsd-jira.digital.nhs.uk/browse/DI-405

## Description

The "get_single_service_odscode" function only works on pharmacies and should not require an input parameter as the function invokes a lambda function which has now been modified to make use of a single "type" parameter to execute the payload query.

### Noteworthy Changes

- Refactor the function in Test suite to retrieve single service pharmacies

## Type of change

Delete not appropriate

- Bug fix (non-breaking change which fixes an issue)

## Testing

Please tick the testing that has been completed

- [ ] Unit tests
- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
