### PR TITLE
DI-185 Create ECR clean up process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ undeploy: # Undeploys whole project - mandatory: PROFILE
 build-and-deploy: # Builds and Deploys whole project - mandatory: PROFILE
 	make build VERSION=$(BUILD_TAG)
 	make push-images VERSION=$(BUILD_TAG)
-	make -s terraform-clean
 	make deploy VERSION=$(BUILD_TAG)
 
 populate-deployment-variables:

--- a/Makefile
+++ b/Makefile
@@ -486,6 +486,46 @@ slack-codebuild-notification: ### Send codebuild pipeline notification - mandato
 		BUILD_URL=$$(echo https://$(AWS_REGION).console.aws.amazon.com/codesuite/codebuild/$(AWS_ACCOUNT_ID_MGMT)/projects/$(CODEBUILD_PROJECT_NAME)/build/$(CODEBUILD_BUILD_ID)/log?region=$(AWS_REGION)) \
 		SLACK_WEBHOOK_URL=$$(make -s secret-get-existing-value NAME=$(SLACK_WEBHOOK_SECRET_NAME) KEY=$(SLACK_WEBHOOK_SECRET_KEY))
 
+aws-ecr-cleanup: # Mandatory: REPOS=[comma separated list of ECR repo names e.g. event-sender,slack-messenger]
+	export THIS_YEAR=$$(date +%Y)
+	export LAST_YEAR=$$(date -d "1 year ago" +%Y)
+	DELETE_IMAGES_OLDER_THAN=$$(date +%s --date='1 month ago')
+	for REPOSITORY in $$(echo $(REPOS) | tr "," "\n"); do
+		REPOSITORY_NAME=$$(echo $(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/$$REPOSITORY)
+		echo Repository is $$REPOSITORY_NAME
+		make remove-untagged-images REPOSITORY=$$REPOSITORY_NAME
+		make remove-task-images REPOSITORY=$$REPOSITORY_NAME DELETE_IMAGES_OLDER_THAN=$$DELETE_IMAGES_OLDER_THAN
+	done
+
+remove-task-images: # Removes task ecr images in repository older than certain date, REPOSITORY=[$(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/REPOSITORY_NAME], DELETE_IMAGES_OLDER_THAN=[date/time in epoch]
+	COUNTER=0
+	IMAGE_IDS=$$(aws ecr describe-images --registry-id $(AWS_ACCOUNT_ID_MGMT) --region $(AWS_REGION) --repository-name $(REPOSITORY) --filter "tagStatus=TAGGED" --max-items 1000 --output json | jq -r '.imageDetails[] | select (.imageTags[0] | contains("$(LAST_YEAR)") or contains ("$(THIS_YEAR)")) | select (.imagePushedAt < $(DELETE_IMAGES_OLDER_THAN)).imageDigest')
+	for DIGEST in $$(echo $$IMAGE_IDS | tr " " "\n"); do
+			IMAGES_TO_DELETE+=$$(echo $$DIGEST | sed '$$s/$$/ /')
+			COUNTER=$$((COUNTER+1))
+			if [ $$COUNTER -eq 100 ]; then
+				make batch-delete-ecr-images LIST_OF_DIGESTS="$$IMAGES_TO_DELETE"
+				IMAGES_TO_DELETE=""
+				COUNTER=0
+			fi
+	done
+	if [[ ! -z "$$IMAGES_TO_DELETE" ]]; then
+		make batch-delete-ecr-images LIST_OF_DIGESTS="$$IMAGES_TO_DELETE"
+	fi
+
+remove-untagged-images: # Removes untagged ecr images in repository, Mandatory - REPOSITORY=[$(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/REPOSITORY_NAME]
+	IMAGE_DIGESTS=$$(aws ecr describe-images --registry-id $(AWS_ACCOUNT_ID_MGMT) --region $(AWS_REGION) --region $(AWS_REGION) --repository-name $(REPOSITORY) --filter "tagStatus=UNTAGGED" --max-items 100 --output json | jq -r .imageDetails[].imageDigest | tr "\n" " ")
+	if [[ ! -z "$$IMAGE_DIGESTS" ]]; then
+		make batch-delete-ecr-images LIST_OF_DIGESTS="$$IMAGE_DIGESTS"
+	fi
+
+batch-delete-ecr-images: # Mandatory - LIST_OF_DIGESTS: [list of "sha:digest" separated by spaces], REPOSITORY=[$(PROJECT_GROUP_SHORT)/$(PROJECT_NAME_SHORT)/REPOSITORY_NAME]
+	for DIGEST in $$(echo $(LIST_OF_DIGESTS) | tr " " "\n"); do
+		IMAGES_TO_DELETE+=$$(echo imageDigest=\"$$DIGEST\" | sed 's/$$/ /')
+	done
+	IMAGE_IDS=$$(echo $$IMAGES_TO_DELETE | sed 's/ $$//')
+	aws ecr batch-delete-image --registry-id $(AWS_ACCOUNT_ID_MGMT) --region $(AWS_REGION) --repository-name $(REPOSITORY) --image-ids $$IMAGE_IDS
+
 # ==============================================================================
 # Tester
 

--- a/infrastructure/stacks/deployment-pipelines/demo_codebuild.tf
+++ b/infrastructure/stacks/deployment-pipelines/demo_codebuild.tf
@@ -82,7 +82,7 @@ resource "aws_codebuild_project" "di_deploy_demo" {
   source_version = "master"
   source {
     type            = "GITHUB"
-    git_clone_depth = 0 # Full Git Clone
+    git_clone_depth = 0
     location        = "https://github.com/nhsd-exeter/dos-integration.git"
     buildspec       = data.template_file.deploy_buildspec.rendered
   }

--- a/infrastructure/stacks/deployment-pipelines/live_codebuild.tf
+++ b/infrastructure/stacks/deployment-pipelines/live_codebuild.tf
@@ -82,7 +82,7 @@ resource "aws_codebuild_project" "di_deploy_live" {
   source_version = "master"
   source {
     type            = "GITHUB"
-    git_clone_depth = 0 # Full Git Clone
+    git_clone_depth = 0
     location        = "https://github.com/nhsd-exeter/dos-integration.git"
     buildspec       = data.template_file.deploy_buildspec.rendered
   }

--- a/infrastructure/stacks/development-pipeline/build-image-buildspec.yml
+++ b/infrastructure/stacks/development-pipeline/build-image-buildspec.yml
@@ -18,3 +18,8 @@ phases:
       - unset AWS_SECRET_ACCESS_KEY
       - unset AWS_SESSION_TOKEN
       - make docker-push NAME=$BUILD_ITEM_NAME
+  finally:
+      - |
+        if [ $CODEBUILD_BUILD_SUCCEEDING -eq 0 ]; then
+          make slack-codebuild-notification PROFILE=$PROFILE ENVIRONMENT=$ENVIRONMENT PIPELINE_NAME="Build $BUILD_ITEM_NAME Image" BUILD_STATUS=failure CODEBUILD_PROJECT_NAME=$CB_PROJECT_NAME CODEBUILD_BUILD_ID=$CODEBUILD_BUILD_ID SLACK_MESSAGE="Delete Failed Please investigate"
+        fi

--- a/infrastructure/stacks/development-pipeline/build_environment.tf
+++ b/infrastructure/stacks/development-pipeline/build_environment.tf
@@ -78,7 +78,7 @@ resource "aws_codebuild_project" "di_build_environment" {
   }
   source {
     type            = "GITHUB"
-    git_clone_depth = 0 # Full Git Clone
+    git_clone_depth = 0
     location        = "https://github.com/nhsd-exeter/dos-integration.git"
     buildspec       = data.template_file.build_environment_buildspec.rendered
   }

--- a/infrastructure/stacks/development-pipeline/build_image_codebuild.tf
+++ b/infrastructure/stacks/development-pipeline/build_image_codebuild.tf
@@ -103,7 +103,7 @@ resource "aws_codebuild_project" "di_build_image" {
   }
   source {
     type            = "GITHUB"
-    git_clone_depth = 0 # Full Git Clone
+    git_clone_depth = 0
     location        = "https://github.com/nhsd-exeter/dos-integration.git"
     buildspec       = data.template_file.build_image_buildspec.rendered
   }

--- a/infrastructure/stacks/development-pipeline/build_image_codebuild.tf
+++ b/infrastructure/stacks/development-pipeline/build_image_codebuild.tf
@@ -1,5 +1,5 @@
 resource "aws_codebuild_webhook" "build_image_webhook" {
-  for_each     = local.independent_build_images
+  for_each     = var.environment == "dev" ? local.independent_build_images : {}
   project_name = "${var.project_id}-${var.environment}-build-${each.key}-stage"
   build_type   = "BUILD"
   filter_group {
@@ -52,7 +52,11 @@ resource "aws_codebuild_project" "di_build_image" {
 
     environment_variable {
       name  = "PROFILE"
-      value = "local"
+      value = "dev"
+    }
+    environment_variable {
+      name  = "ENVIRONMENT"
+      value = "dev"
     }
     environment_variable {
       name  = "BUILD_TARGET"
@@ -61,6 +65,10 @@ resource "aws_codebuild_project" "di_build_image" {
     environment_variable {
       name  = "BUILD_ITEM_NAME"
       value = each.key
+    }
+    environment_variable {
+      name  = "CB_PROJECT_NAME"
+      value = "${var.project_id}-${var.environment}-build-${each.key}-stage"
     }
     environment_variable {
       name  = "ENVIRONMENT"

--- a/infrastructure/stacks/development-pipeline/codepipeline.tf
+++ b/infrastructure/stacks/development-pipeline/codepipeline.tf
@@ -106,8 +106,9 @@ resource "aws_codepipeline" "codepipeline" {
       }
     }
   }
-
+  depends_on = [module.codepipeline_artefact_bucket]
 }
+
 resource "aws_codestarconnections_connection" "github" {
   name          = "${var.project_id}-codestarconnection"
   provider_type = "GitHub"

--- a/infrastructure/stacks/development-pipeline/data.tf
+++ b/infrastructure/stacks/development-pipeline/data.tf
@@ -30,6 +30,10 @@ data "template_file" "build_environment_buildspec" {
   template = file("build-environment-buildspec.yml")
 }
 
+data "template_file" "delete_ecr_images_buildspec" {
+  template = file("delete-ecr-images-buildspec.yml")
+}
+
 data "aws_iam_role" "pipeline_role" {
   name = "UECPUPipelineRole"
 }

--- a/infrastructure/stacks/development-pipeline/delete-ecr-images-buildspec.yml
+++ b/infrastructure/stacks/development-pipeline/delete-ecr-images-buildspec.yml
@@ -9,3 +9,8 @@ phases:
       - export AWS_SESSION_TOKEN=$(echo $temp_role | jq -r .Credentials.SessionToken)
       - aws sts get-caller-identity
       - make aws-ecr-cleanup REPOS=authoriser,cr-fifo-dlq-handler,dos-api-gateway,event-processor,event-replay,event-sender,fifo-dlq-handler,slack-messenger,test-db-checker-handler
+    finally:
+        - |
+          if [ $CODEBUILD_BUILD_SUCCEEDING -eq 0 ]; then
+            make slack-codebuild-notification PROFILE=$PROFILE ENVIRONMENT=$ENVIRONMENT PIPELINE_NAME="Delete ECR Images" BUILD_STATUS=failure CODEBUILD_PROJECT_NAME=$CB_PROJECT_NAME CODEBUILD_BUILD_ID=$CODEBUILD_BUILD_ID SLACK_MESSAGE="Delete Failed Please investigate"
+          fi

--- a/infrastructure/stacks/development-pipeline/delete-ecr-images-buildspec.yml
+++ b/infrastructure/stacks/development-pipeline/delete-ecr-images-buildspec.yml
@@ -1,0 +1,11 @@
+version: 0.2
+
+phases:
+  build:
+    commands:
+      - temp_role=$(aws sts assume-role --role-arn "arn:aws:iam::$AWS_ACCOUNT_ID_NONPROD:role/UECPUPipelineBuildRole" --role-session-name "CodeBuildSession")
+      - export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq -r .Credentials.AccessKeyId)
+      - export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq -r .Credentials.SecretAccessKey)
+      - export AWS_SESSION_TOKEN=$(echo $temp_role | jq -r .Credentials.SessionToken)
+      - aws sts get-caller-identity
+      - make aws-ecr-cleanup REPOS=authoriser,cr-fifo-dlq-handler,dos-api-gateway,event-processor,event-replay,event-sender,fifo-dlq-handler,slack-messenger,test-db-checker-handler

--- a/infrastructure/stacks/development-pipeline/delete-task-environment-from-tag-buildspec.yml
+++ b/infrastructure/stacks/development-pipeline/delete-task-environment-from-tag-buildspec.yml
@@ -21,3 +21,10 @@ phases:
       - if [ -n "$ENVIRONMENT_DEPLOYED" ]; then
           make undeploy PROFILE=$PROFILE ENVIRONMENT=$ENVIRONMENT ;
         fi
+    finally:
+          - |
+            if [ $CODEBUILD_BUILD_SUCCEEDING -eq 0 ]; then
+              make slack-codebuild-notification PROFILE=$PROFILE ENVIRONMENT=$ENVIRONMENT PIPELINE_NAME="Delete Task Environment from Tag Codebuild Stage" BUILD_STATUS=failure CODEBUILD_PROJECT_NAME=$CB_PROJECT_NAME CODEBUILD_BUILD_ID=$CODEBUILD_BUILD_ID SLACK_MESSAGE="Delete Failed Please investigate"
+            else
+              make slack-codebuild-notification PROFILE=$PROFILE ENVIRONMENT=$ENVIRONMENT PIPELINE_NAME="Delete Task Environment from Tag Codebuild Stage" BUILD_STATUS=success CODEBUILD_PROJECT_NAME=$CB_PROJECT_NAME CODEBUILD_BUILD_ID=$CODEBUILD_BUILD_ID SLACK_MESSAGE="Delete Succeeded"
+            fi

--- a/infrastructure/stacks/development-pipeline/delete-task-environment-on-pr-merged-buildspec.yml
+++ b/infrastructure/stacks/development-pipeline/delete-task-environment-on-pr-merged-buildspec.yml
@@ -34,3 +34,10 @@ phases:
       - if [ -n "$ENVIRONMENT_DEPLOYED" ]; then
           make undeploy PROFILE=$PROFILE ENVIRONMENT=$ENVIRONMENT ;
         fi
+    finally:
+      - |
+        if [ $CODEBUILD_BUILD_SUCCEEDING -eq 0 ]; then
+          make slack-codebuild-notification ENVIRONMENT=$ENVIRONMENT PROFILE=$PROFILE PIPELINE_NAME="Delete Environment After Merge Codebuild Stage" BUILD_STATUS=failure CODEBUILD_PROJECT_NAME=$CB_PROJECT_NAME CODEBUILD_BUILD_ID=$CODEBUILD_BUILD_ID SLACK_MESSAGE="Delete Failed Please investigate"
+        else
+          make slack-codebuild-notification ENVIRONMENT=$ENVIRONMENT PROFILE=$PROFILE PIPELINE_NAME="Delete Environment After Merge Codebuild Stage" BUILD_STATUS=success CODEBUILD_PROJECT_NAME=$CB_PROJECT_NAME CODEBUILD_BUILD_ID=$CODEBUILD_BUILD_ID SLACK_MESSAGE="Delete Succeeded"
+        fi

--- a/infrastructure/stacks/development-pipeline/delete_ecr_images.tf
+++ b/infrastructure/stacks/development-pipeline/delete_ecr_images.tf
@@ -74,7 +74,7 @@ resource "aws_codebuild_project" "di_delete_ecr_images" {
   }
   source {
     type            = "GITHUB"
-    git_clone_depth = 0 # Full Git Clone
+    git_clone_depth = 0
     location        = "https://github.com/nhsd-exeter/dos-integration.git"
     buildspec       = data.template_file.delete_ecr_images_buildspec.rendered
   }

--- a/infrastructure/stacks/development-pipeline/delete_ecr_images.tf
+++ b/infrastructure/stacks/development-pipeline/delete_ecr_images.tf
@@ -1,0 +1,74 @@
+resource "aws_cloudwatch_event_rule" "cron_for_delete_images" {
+  name                = "${var.project_id}-${var.environment}-delete-ecr-images-rule"
+  schedule_expression = "cron(0 20 * * ? *)"
+}
+
+resource "aws_cloudwatch_event_target" "trigger_delete_ecr_images" {
+  rule = aws_cloudwatch_event_rule.cron_for_delete_images.name
+  arn  = aws_codebuild_project.di_delete_ecr_images.arn
+}
+
+
+resource "aws_codebuild_project" "di_delete_ecr_images" {
+  name           = "${var.project_id}-${var.environment}-delete-ecr-images-stage"
+  description    = "Deletes ECR images"
+  build_timeout  = "30"
+  queued_timeout = "5"
+  service_role   = data.aws_iam_role.pipeline_role.arn
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  cache {
+    type  = "LOCAL"
+    modes = ["LOCAL_DOCKER_LAYER_CACHE", "LOCAL_SOURCE_CACHE"]
+  }
+
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "aws/codebuild/amazonlinux2-x86_64-standard:3.0"
+    type                        = "LINUX_CONTAINER"
+    image_pull_credentials_type = "CODEBUILD"
+    privileged_mode             = true
+
+    environment_variable {
+      name  = "PROFILE"
+      value = "task"
+    }
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID_LIVE_PARENT"
+      value = var.aws_account_id_live_parent
+    }
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID_MGMT"
+      value = var.aws_account_id_mgmt
+    }
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID_NONPROD"
+      value = var.aws_account_id_nonprod
+    }
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID_PROD"
+      value = var.aws_account_id_prod
+    }
+    environment_variable {
+      name  = "AWS_ACCOUNT_ID_IDENTITIES"
+      value = var.aws_account_id_identities
+    }
+  }
+  logs_config {
+    cloudwatch_logs {
+      group_name  = "/aws/codebuild/${var.project_id}-${var.environment}-delete-ecr-images"
+      stream_name = ""
+    }
+  }
+  source {
+    type            = "GITHUB"
+    git_clone_depth = 0 # Full Git Clone
+    location        = "https://github.com/nhsd-exeter/dos-integration.git"
+    buildspec       = data.template_file.delete_ecr_images_buildspec.rendered
+  }
+
+}

--- a/infrastructure/stacks/development-pipeline/delete_ecr_images.tf
+++ b/infrastructure/stacks/development-pipeline/delete_ecr_images.tf
@@ -35,7 +35,15 @@ resource "aws_codebuild_project" "di_delete_ecr_images" {
 
     environment_variable {
       name  = "PROFILE"
-      value = "task"
+      value = "dev"
+    }
+    environment_variable {
+      name  = "ENVIRONMENT"
+      value = "dev"
+    }
+    environment_variable {
+      name  = "CB_PROJECT_NAME"
+      value = "${var.project_id}-${var.environment}-delete-ecr-images-stage"
     }
     environment_variable {
       name  = "AWS_ACCOUNT_ID_LIVE_PARENT"

--- a/infrastructure/stacks/development-pipeline/delete_task_environment_from_tag.tf
+++ b/infrastructure/stacks/development-pipeline/delete_task_environment_from_tag.tf
@@ -88,7 +88,7 @@ resource "aws_codebuild_project" "di_destroy_environment_from_tag" {
   }
   source {
     type            = "GITHUB"
-    git_clone_depth = 0 # Full Git Clone
+    git_clone_depth = 0
     location        = "https://github.com/nhsd-exeter/dos-integration.git"
     buildspec       = data.template_file.delete_task_environment_from_tag_buildspec.rendered
   }

--- a/infrastructure/stacks/development-pipeline/delete_task_environment_from_tag.tf
+++ b/infrastructure/stacks/development-pipeline/delete_task_environment_from_tag.tf
@@ -56,6 +56,10 @@ resource "aws_codebuild_project" "di_destroy_environment_from_tag" {
       value = "task"
     }
     environment_variable {
+      name  = "CB_PROJECT_NAME"
+      value = "${var.project_id}-${var.environment}-destroy-task-environments-stage"
+    }
+    environment_variable {
       name  = "AWS_ACCOUNT_ID_LIVE_PARENT"
       value = var.aws_account_id_live_parent
     }

--- a/infrastructure/stacks/development-pipeline/delete_task_environment_on_pr_merged.tf
+++ b/infrastructure/stacks/development-pipeline/delete_task_environment_on_pr_merged.tf
@@ -76,7 +76,7 @@ resource "aws_codebuild_project" "di_destroy_environment_on_pr_merged" {
   }
   source {
     type            = "GITHUB"
-    git_clone_depth = 0 # Full Git Clone
+    git_clone_depth = 0
     location        = "https://github.com/nhsd-exeter/dos-integration.git"
     buildspec       = data.template_file.delete_task_environment_on_pr_merged_buildspec.rendered
   }

--- a/infrastructure/stacks/development-pipeline/delete_task_environment_on_pr_merged.tf
+++ b/infrastructure/stacks/development-pipeline/delete_task_environment_on_pr_merged.tf
@@ -40,6 +40,10 @@ resource "aws_codebuild_project" "di_destroy_environment_on_pr_merged" {
       value = "task"
     }
     environment_variable {
+      name  = "CB_PROJECT_NAME"
+      value = "${var.project_id}-${var.environment}-destroy-task-environment-on-pr-merged-stage"
+    }
+    environment_variable {
       name  = "AWS_ACCOUNT_ID_LIVE_PARENT"
       value = var.aws_account_id_live_parent
     }


### PR DESCRIPTION
## Link to JIRA Ticket

- https://nhsd-jira.digital.nhs.uk/browse/DI-185

## Description

This PR is create an AWS codebuild stage to delete ECR images. The images that will be deleted are ones that are untagged and ones that are tagged for the task environment and older than a month. To find the image is a task environment image I check for the year in the repository such as 2022 or 2021.  Also images have to be older than a month as when an image is deleted and it is still used by the cloudformation stack it complains on update. So to fix this only old images will be removed as we don't tend to hold on to environments for that long. If this does occur destroying and rebuilding the environment will clear the issue
A good example is build 28 of the codebuild project.

### Noteworthy Changes

- This has been tested on the event-sender repository
- This codebuild project is capable of deleting 2000 images per run per repository. (1000 untagged and 1000 tagged) Roughly 250 images per repository are pushed each month. 
- Repositories still need to be removed in the Non-Prod and Prod accounts
- The schedule that is going to be added will be once a month. 

## Type of change

- New feature (non-breaking change which adds functionality)

## Developer Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the [code formatting checks](../README.md#code-quality)
- [x] I have run the [code quality checks](../README.md#code-quality)
- [x] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [x] Unit test code coverage is at or above 80%
- [x] New and existing unit tests pass locally with my changes
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
