### PR TITLE
DI-406 Edge cases for dentist ods

### DIFF
--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -158,31 +158,26 @@ Feature: F002. Invalid change event Exception handling
     Then the Event Processor logs to splunk with report key "INVALID_OPEN_TIMES"
 
 @complete @cloudwatch_queries
-  Scenario: F002S021. Dentist Unmatched Service Type uses correct report key
+  Scenario Outline: F002S021. Dentist Unmatched Pharmacy and Service report keys
     Given a Dentist Changed Event is valid
-    And the Changed Event has ODS Code "FQG8101"
+    And the Changed Event has ODS Code "<ods_code>"
     When the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor logs to splunk with report key "UNMATCHED_SERVICE_TYPE"
+    Then the Event Processor logs to splunk with report key "<report_key>"
+
+  Examples:
+    | ods_code |       report_key       |
+    | FQG8101  | UNMATCHED_SERVICE_TYPE |
+    | V00393b  |   UNMATCHED_PHARMACY   |
 
 @complete @cloudwatch_queries
-  Scenario: F002S022. Dentist Unmatched Service uses correct report key
+  Scenario Outline: F002S023. Dentists with Invalid ODS Lengths.
     Given a Dentist Changed Event is valid
-    And the Changed Event has ODS Code "V00393b"
-    When the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor logs to splunk with report key "UNMATCHED_PHARMACY"
-
-@complete @cloudwatch_queries
-  Scenario: F002S023. Dentist Request with ODS code too short.
-    Given a Dentist Changed Event is valid
-    And the Changed Event has ODS Code "V00393"
+    And the Changed Event has ODS Code "<ods_code>"
     When the Changed Event is sent for processing with "valid" api key
     Then the Event "processor" shows field "error" with message "ODSCode Wrong Length"
     And the Event "processor" does not show "message" with message "Getting matching DoS Services for odscode"
 
-@complete @cloudwatch_queries
-  Scenario: F002S024. Dentist Request with ODS code too long.
-    Given a Dentist Changed Event is valid
-    And the Changed Event has ODS Code "V00393abc"
-    When the Changed Event is sent for processing with "valid" api key
-    Then the Event "processor" shows field "error" with message "ODSCode Wrong Length"
-    And the Event "processor" does not show "message" with message "Getting matching DoS Services for odscode"
+  Examples:
+    |  ods_code   |
+    |   V00393    |
+    |  V00393abc  |

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -141,28 +141,28 @@ Feature: F002. Invalid change event Exception handling
     Given a Dentist Changed Event is valid
     When the OrganisationStatus is defined as "Hidden"
     And the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor logs to splunk with report key "HIDDEN_OR_CLOSED"
+    Then the Event Processor logs with report key "HIDDEN_OR_CLOSED"
 
 @complete @cloudwatch_queries
   Scenario: F002S019. Dentist Invalid Postcode uses correct report key
     Given a Dentist Changed Event is valid
     When the postcode is invalid
     And the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor logs to splunk with report key "INVALID_POSTCODE"
+    Then the Event Processor logs with report key "INVALID_POSTCODE"
 
 @complete @cloudwatch_queries
   Scenario: F002S020. Dentist Invalid Opening Times uses correct report key
     Given a Dentist Changed Event is valid
     And a Changed Event where OpeningTimeType is NOT defined correctly
     When the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor logs to splunk with report key "INVALID_OPEN_TIMES"
+    Then the Event Processor logs with report key "INVALID_OPEN_TIMES"
 
 @complete @cloudwatch_queries
   Scenario Outline: F002S021. Dentist Unmatched Pharmacy and Service report keys
     Given a Dentist Changed Event is valid
     And the Changed Event has ODS Code "<ods_code>"
     When the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor logs to splunk with report key "<report_key>"
+    Then the Event Processor logs with report key "<report_key>"
 
   Examples:
     | ods_code |       report_key       |

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -170,3 +170,19 @@ Feature: F002. Invalid change event Exception handling
     And the Changed Event has ODS Code "V00393b"
     When the Changed Event is sent for processing with "valid" api key
     Then the Event Processor logs to splunk with report key "UNMATCHED_PHARMACY"
+
+@complete @cloudwatch_queries
+  Scenario: F002S023. Dentist Request with ODS code too short.
+    Given a Dentist Changed Event is valid
+    And the Changed Event has ODS Code "V00393"
+    When the Changed Event is sent for processing with "valid" api key
+    Then the Event Processor shows field "error" with message "ODSCode Wrong Length"
+    And the Event Processor does not show "message" with message "Getting matching DoS Services for odscode"
+
+@complete @cloudwatch_queries
+  Scenario: F002S024. Dentist Request with ODS code too long.
+    Given a Dentist Changed Event is valid
+    And the Changed Event has ODS Code "V00393abc"
+    When the Changed Event is sent for processing with "valid" api key
+    Then the Event Processor shows field "error" with message "ODSCode Wrong Length"
+    And the Event Processor does not show "message" with message "Getting matching DoS Services for odscode"

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -171,7 +171,7 @@ Feature: F002. Invalid change event Exception handling
     When the Changed Event is sent for processing with "valid" api key
     Then the Event Processor logs to splunk with report key "UNMATCHED_PHARMACY"
 
-@complete @cloudwatch_queries @kit
+@complete @cloudwatch_queries
   Scenario: F002S023. Dentist Request with ODS code too short.
     Given a Dentist Changed Event is valid
     And the Changed Event has ODS Code "V00393"
@@ -179,7 +179,7 @@ Feature: F002. Invalid change event Exception handling
     Then the Event "processor" shows field "error" with message "ODSCode Wrong Length"
     And the Event "processor" does not show "message" with message "Getting matching DoS Services for odscode"
 
-@complete @cloudwatch_queries @kit
+@complete @cloudwatch_queries
   Scenario: F002S024. Dentist Request with ODS code too long.
     Given a Dentist Changed Event is valid
     And the Changed Event has ODS Code "V00393abc"

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -171,18 +171,18 @@ Feature: F002. Invalid change event Exception handling
     When the Changed Event is sent for processing with "valid" api key
     Then the Event Processor logs to splunk with report key "UNMATCHED_PHARMACY"
 
-@complete @cloudwatch_queries
+@complete @cloudwatch_queries @kit
   Scenario: F002S023. Dentist Request with ODS code too short.
     Given a Dentist Changed Event is valid
     And the Changed Event has ODS Code "V00393"
     When the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor shows field "error" with message "ODSCode Wrong Length"
-    And the Event Processor does not show "message" with message "Getting matching DoS Services for odscode"
+    Then the Event "processor" shows field "error" with message "ODSCode Wrong Length"
+    And the Event "processor" does not show "message" with message "Getting matching DoS Services for odscode"
 
-@complete @cloudwatch_queries
+@complete @cloudwatch_queries @kit
   Scenario: F002S024. Dentist Request with ODS code too long.
     Given a Dentist Changed Event is valid
     And the Changed Event has ODS Code "V00393abc"
     When the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor shows field "error" with message "ODSCode Wrong Length"
-    And the Event Processor does not show "message" with message "Getting matching DoS Services for odscode"
+    Then the Event "processor" shows field "error" with message "ODSCode Wrong Length"
+    And the Event "processor" does not show "message" with message "Getting matching DoS Services for odscode"

--- a/test/integration/steps/test_parent_steps.py
+++ b/test/integration/steps/test_parent_steps.py
@@ -877,47 +877,36 @@ def check_logs_for_correct_report_key(context, reportkey):
     ), f"ERROR!!.. error event processor did not detect the report key {reportkey}."
 
 
-@then(parsers.parse('the Event Processor shows field "{field}" with message "{message}"'))
-def generic_processor_check_function(context, field, message):
-    if field != "message":
-        fields = "message, " + field
-    else:
-        fields = field
-
+@then(parsers.parse('the Event "{processor}" shows field "{field}" with message "{message}"'))
+def generic_processor_check_function(context, processor, field, message):
     query = (
-        f"fields {fields} | sort @timestamp asc"
+        f"fields {field} | sort @timestamp asc"
         f' | filter correlation_id="{context["correlation_id"]}" | filter {field} like "{message}"'
     )
-    logs = get_logs(query, "processor", context["start_time"])
+    logs = get_logs(query, processor, context["start_time"])
     assert message in logs, f"ERROR!!.. error event processor did not detect the {field}: {message}."
 
 
-@then(parsers.parse('the Event Processor does not show "{field}" with message "{message}"'))
-def generic_processor_negative_check_function(context, field, message):
-    if field != "message":
-        field = "message, " + field
-    else:
-        fields = field
-
+@then(parsers.parse('the Event "{processor}" does not show "{field}" with message "{message}"'))
+def generic_processor_negative_check_function(context, processor, field, message):
     find_request_id_query = (
-        f"fields function_request_id | sort @timestamp asc" f' | filter correlation_id="{context["correlation_id"]}"'
+        "fields function_request_id | sort @timestamp asc" f' | filter correlation_id="{context["correlation_id"]}"'
     )
-    find_request_id = loads(get_logs(find_request_id_query, "processor", context["start_time"]))
+    find_request_id = loads(get_logs(find_request_id_query, processor, context["start_time"]))
 
     request_id = ""
     for x in find_request_id["results"][0]:
         if x["field"] == "function_request_id":
             request_id = x["value"]
 
-    finished_check = "fields @message" f' | filter @requestId == "{request_id}" | filter @type == "END"'
-    logs = get_logs(finished_check, "processor", context["start_time"], 10)
-    if logs == []:
-        raise ValueError("The Lambda has not finished running")
+    finished_check = f'fields @message | filter @requestId == "{request_id}" | filter @type == "END"'
+
+    get_logs(finished_check, processor, context["start_time"], 2)
 
     query = (
-        f"fields {fields} | sort @timestamp asc"
+        f"fields {field} | sort @timestamp asc"
         f' | filter correlation_id="{context["correlation_id"]}" | filter {field} like "{message}"'
     )
-    logs_found = negative_log_check(query, "processor", context["start_time"])
+    logs_found = negative_log_check(query, processor, context["start_time"])
 
     assert logs_found is True, f"ERROR!!.. error event processor did not detect the {field}: {message}."

--- a/test/integration/steps/test_parent_steps.py
+++ b/test/integration/steps/test_parent_steps.py
@@ -18,7 +18,7 @@ from .utilities.events import (
     valid_change_event,
 )
 from .utilities.constants import DENTIST_ORG_TYPE_ID, ORGANISATION_SUB_TYPES_KEY
-from .utilities.aws import get_logs
+from .utilities.aws import get_logs, negative_log_check
 from .utilities.utils import (
     generate_correlation_id,
     get_changes,
@@ -875,3 +875,49 @@ def check_logs_for_correct_report_key(context, reportkey):
     assert (
         context["change_event"]["ODSCode"] in logs
     ), f"ERROR!!.. error event processor did not detect the report key {reportkey}."
+
+
+@then(parsers.parse('the Event Processor shows field "{field}" with message "{message}"'))
+def generic_processor_check_function(context, field, message):
+    if field != "message":
+        fields = "message, " + field
+    else:
+        fields = field
+
+    query = (
+        f"fields {fields} | sort @timestamp asc"
+        f' | filter correlation_id="{context["correlation_id"]}" | filter {field} like "{message}"'
+    )
+    logs = get_logs(query, "processor", context["start_time"])
+    assert message in logs, f"ERROR!!.. error event processor did not detect the {field}: {message}."
+
+
+@then(parsers.parse('the Event Processor does not show "{field}" with message "{message}"'))
+def generic_processor_negative_check_function(context, field, message):
+    if field != "message":
+        field = "message, " + field
+    else:
+        fields = field
+
+    find_request_id_query = (
+        f"fields function_request_id | sort @timestamp asc" f' | filter correlation_id="{context["correlation_id"]}"'
+    )
+    find_request_id = loads(get_logs(find_request_id_query, "processor", context["start_time"]))
+
+    request_id = ""
+    for x in find_request_id["results"][0]:
+        if x["field"] == "function_request_id":
+            request_id = x["value"]
+
+    finished_check = "fields @message" f' | filter @requestId == "{request_id}" | filter @type == "END"'
+    logs = get_logs(finished_check, "processor", context["start_time"], 10)
+    if logs == []:
+        raise ValueError("The Lambda has not finished running")
+
+    query = (
+        f"fields {fields} | sort @timestamp asc"
+        f' | filter correlation_id="{context["correlation_id"]}" | filter {field} like "{message}"'
+    )
+    logs_found = negative_log_check(query, "processor", context["start_time"])
+
+    assert logs_found is True, f"ERROR!!.. error event processor did not detect the {field}: {message}."

--- a/test/integration/steps/test_parent_steps.py
+++ b/test/integration/steps/test_parent_steps.py
@@ -865,7 +865,7 @@ def check_logs_for_correct_sent_cr(context, odscode):
     assert odscode in logs, "ERROR!!.. error sender does not have correct ods."
 
 
-@then(parsers.parse('the Event Processor logs to splunk with report key "{reportkey}"'))
+@then(parsers.parse('the Event Processor logs with report key "{reportkey}"'))
 def check_logs_for_correct_report_key(context, reportkey):
     query = (
         "fields message, report_key, ods_code | sort @timestamp asc"

--- a/test/integration/steps/utilities/aws.py
+++ b/test/integration/steps/utilities/aws.py
@@ -85,7 +85,7 @@ def negative_log_check(query: str, event_lambda: str, start_time: Timestamp) -> 
     )
 
     query_id = start_query_response["queryId"]
-    sleep(120)
+    sleep(30)
     response = LAMBDA_CLIENT_LOGS.get_query_results(queryId=query_id)
 
     if response["results"] == []:


### PR DESCRIPTION
## Link to JIRA Ticket

- https://nhsd-jira.digital.nhs.uk/browse/DI-406

## Description

This ticket adds a few new things.
There is a new generic log check step that will enable the user to specify a log group, a field, and a message to be verified. This will allow multiple tests to be moved across to this format, limiting the amount of test steps that are required.
There is also a new step that checks the opposite, that a certain log entry is not present, however this has required multiple requests to be made.
The new function in aws.py verifies that no logs are returned, and returns True, if nothing was found.
The new step runs the following:
An initial request to check logs for the correlation ID to find the function request ID.
A second request to ensure that the end step for the request ID has been found. This ensures that the Lambda has finished running.
A third request to verify that the log entry has not been found.

When running tests to verify performance change the 3 requests added ~20s to the runtime of the standard single request entry. This isn't too bad, as the negative check will be performed considerably less than the positive check. In the test environment results can be affected greatly by simultaneous test runs, which cannot be validated on my machine. Anyone reviewing should run these tests as part of a larger parallel test run.

An arg has also been added to the get_logs function so that the test can specify how long to retry for. This defaults to 32, which was the value set previously.

### Noteworthy Changes

- These are changes the reviewer should look out for

## Type of change

Test

## Testing

Please tick the testing that has been completed

- [ ] Unit tests
- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
