### PR TITLE
DI-409 Refactoring of log check tests

### DIFF
--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -4,9 +4,9 @@ Feature: F002. Invalid change event Exception handling
   Scenario: F002S001. Unmatched DOS services exception is logged
     Given a Changed Event with invalid ODSCode is provided
     When the Changed Event is sent for processing with "valid" api key
-    Then no matched services were found
-    And the unmatched service exception is reported to cloudwatch
-    Then the Changed Event is not processed any further
+    Then the Event "processor" shows field "message" with message "Found 0 services in DB"
+    And the Event "processor" shows field "message" with message "No matching DOS services"
+    And the Event "processor" does not show "message" with message "Received change request"
     And the Changed Event is not sent to Dos
     And the Changed Event is stored in dynamo db
 
@@ -15,7 +15,7 @@ Feature: F002. Invalid change event Exception handling
     Given a Changed Event is valid
     When the OrganisationStatus is defined as "Hidden"
     And the Changed Event is sent for processing with "valid" api key
-    Then the hidden or closed exception is reported to cloudwatch
+    Then the Event "processor" shows field "message" with message "NHS Service marked as closed or hidden"
     And the Changed Event is stored in dynamo db
 
   @complete @dev @cloudwatch_queries
@@ -23,23 +23,23 @@ Feature: F002. Invalid change event Exception handling
     Given a Changed Event is valid
     When the OrganisationStatus is defined as "Closed"
     And the Changed Event is sent for processing with "valid" api key
-    Then the Changed Event is not processed any further
+    Then the Event "processor" does not show "message" with message "Received change request"
     And the Changed Event is stored in dynamo db
 
   @complete @dev @cloudwatch_queries
   Scenario: F002S004. A Changed Event where OrganisationTypeID is NOT PHA is reported and ignored
     Given a Changed Event contains an incorrect OrganisationTypeID
     When the Changed Event is sent for processing with "valid" api key
-    Then the exception is reported to cloudwatch
-    And the Changed Event is not processed any further
+    Then the Event "processor" shows field "message" with message "Validation Error - Unexpected Org Type"
+    And the Event "processor" does not show "message" with message "Received change request"
     And the Changed Event is stored in dynamo db
 
   @complete @dev @cloudwatch_queries
   Scenario: F002S005. A Changed Event where OrganisationSubType is NOT Community is reported and ignored
     Given a Changed Event contains an incorrect OrganisationSubtype
     When the Changed Event is sent for processing with "valid" api key
-    Then the exception is reported to cloudwatch
-    And the Changed Event is not processed any further
+    Then the Event "processor" shows field "message" with message "Validation Error - Unexpected Org Sub Type ID"
+    And the Event "processor" does not show "message" with message "Received change request"
     And the Changed Event is stored in dynamo db
 
   @complete @dev @cloudwatch_queries
@@ -47,7 +47,7 @@ Feature: F002. Invalid change event Exception handling
     Given a Changed Event is valid
     When the postcode has no LAT Long values
     And the Changed Event is sent for processing with "valid" api key
-    Then the invalid postcode exception is reported to cloudwatch
+    Then the Event "processor" shows field "report_key" with message "INVALID_POSTCODE"
     And the Changed Event is stored in dynamo db
 
 @complete @dev @cloudwatch_queries
@@ -64,6 +64,7 @@ Feature: F002. Invalid change event Exception handling
     Given a Changed Event with the Weekday NOT present in the Opening Times data
     When the Changed Event is sent for processing with "valid" api key
     Then the OpeningTimes exception is reported to cloudwatch
+    And the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"
     And the Changed Event is stored in dynamo db
 
   @complete @dev @cloudwatch_queries
@@ -71,6 +72,7 @@ Feature: F002. Invalid change event Exception handling
     Given a Changed Event where OpeningTimeType is NOT defined correctly
     When the Changed Event is sent for processing with "valid" api key
     Then the OpeningTimes exception is reported to cloudwatch
+    And the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"
     And the Changed Event is stored in dynamo db
 
 @complete @dev @cloudwatch_queries
@@ -79,6 +81,7 @@ Feature: F002. Invalid change event Exception handling
     When the OpeningTimes Opening and Closing Times data are not defined
     And the Changed Event is sent for processing with "valid" api key
     Then the OpeningTimes exception is reported to cloudwatch
+    And the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"
     And the Changed Event is stored in dynamo db
 
 @complete @dev @cloudwatch_queries
@@ -86,6 +89,7 @@ Feature: F002. Invalid change event Exception handling
     Given a Changed Event with the openingTimes IsOpen status set to false
     When the Changed Event is sent for processing with "valid" api key
     Then the OpeningTimes exception is reported to cloudwatch
+    And the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"
     And the Changed Event is stored in dynamo db
 
   @complete @dev @cloudwatch_queries
@@ -94,6 +98,7 @@ Feature: F002. Invalid change event Exception handling
     When the OpeningTimes OpeningTimeType is Additional and AdditionalOpeningDate is not defined
     And the Changed Event is sent for processing with "valid" api key
     Then the OpeningTimes exception is reported to cloudwatch
+    And the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"
     And the Changed Event is stored in dynamo db
 
   @complete @dev @cloudwatch_queries
@@ -102,6 +107,7 @@ Feature: F002. Invalid change event Exception handling
     When an AdditionalOpeningDate contains data with both true and false IsOpen status
     And the Changed Event is sent for processing with "valid" api key
     Then the OpeningTimes exception is reported to cloudwatch
+    And the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"
     And the Changed Event is stored in dynamo db
 
 @complete @dev @cloudwatch_queries
@@ -118,7 +124,7 @@ Feature: F002. Invalid change event Exception handling
     And the Changed Event has overlapping opening times
     When the Changed Event is sent for processing with "valid" api key
     Then the Changed Event is stored in dynamo db
-    And an invalid opening times error is generated
+    And the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"
 
 @complete @dev @cloudwatch_queries
   Scenario: F002S016. Pharmacy with non '13%' service type code prompts error.
@@ -126,7 +132,7 @@ Feature: F002. Invalid change event Exception handling
     And the Changed Event has ODS Code "TP68G"
     When the Changed Event is sent for processing with "valid" api key
     Then the Changed Event is stored in dynamo db
-    And the unmatched service type exception is reported to cloudwatch
+    And the Event "processor" shows field "report_key" with message "UNMATCHED_SERVICE_TYPE"
 
 @complete @dev @cloudwatch_queries
   Scenario: F002S017. Pharmacies with generic bank holidays are reported in logs.
@@ -134,35 +140,35 @@ Feature: F002. Invalid change event Exception handling
     And the Changed Event has ODS Code "FJQ49"
     When the Changed Event is sent for processing with "valid" api key
     Then the Changed Event is stored in dynamo db
-    And the generic bank holiday exception is reported to cloudwatch
+    And the Event "processor" shows field "report_key" with message "GENERIC_BANK_HOLIDAY"
 
 @complete @cloudwatch_queries
   Scenario: F002S018. Dentist Hidden uses correct report key
     Given a Dentist Changed Event is valid
     When the OrganisationStatus is defined as "Hidden"
     And the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor logs with report key "HIDDEN_OR_CLOSED"
+    Then the Event "processor" shows field "report_key" with message "HIDDEN_OR_CLOSED"
 
 @complete @cloudwatch_queries
   Scenario: F002S019. Dentist Invalid Postcode uses correct report key
     Given a Dentist Changed Event is valid
     When the postcode is invalid
     And the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor logs with report key "INVALID_POSTCODE"
+    Then the Event "processor" shows field "report_key" with message "INVALID_POSTCODE"
 
 @complete @cloudwatch_queries
   Scenario: F002S020. Dentist Invalid Opening Times uses correct report key
     Given a Dentist Changed Event is valid
     And a Changed Event where OpeningTimeType is NOT defined correctly
     When the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor logs with report key "INVALID_OPEN_TIMES"
+    Then the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"
 
 @complete @cloudwatch_queries
   Scenario Outline: F002S021. Dentist Unmatched Pharmacy and Service report keys
     Given a Dentist Changed Event is valid
     And the Changed Event has ODS Code "<ods_code>"
     When the Changed Event is sent for processing with "valid" api key
-    Then the Event Processor logs with report key "<report_key>"
+    Then the Event "processor" shows field "report_key" with message "<report_key>"
 
   Examples:
     | ods_code |       report_key       |

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -176,7 +176,7 @@ Feature: F002. Invalid change event Exception handling
     | V00393b  |   UNMATCHED_PHARMACY   |
 
 @complete @cloudwatch_queries
-  Scenario Outline: F002S023. Dentists with Invalid ODS Lengths.
+  Scenario Outline: F002S022. Dentists with Invalid ODS Lengths.
     Given a Dentist Changed Event is valid
     And the Changed Event has ODS Code "<ods_code>"
     When the Changed Event is sent for processing with "valid" api key

--- a/test/integration/features/F004_Error_Handling.feature
+++ b/test/integration/features/F004_Error_Handling.feature
@@ -5,9 +5,9 @@ Feature: F004. Error Handling
     Given a Changed Event is valid
     And the correlation-id is "Bad Request"
     When the Changed Event is sent for processing with "valid" api key
-    Then the event is sent to the DLQ
-    And the DLQ logs the error for Splunk
-    And the "cr_dlq" logs show status code "400"
+    Then the Event "sender" shows field "response_text" with message "Fake Bad Request"
+    And the Event "cr_dlq" shows field "report_key" with message "CR_DLQ_HANDLER_RECEIVED_EVENT"
+    And the Event "cr_dlq" shows field "error_msg_http_code" with message "400"
     And the Changed Event is stored in dynamo db
 
   @dev
@@ -15,7 +15,7 @@ Feature: F004. Error Handling
     Given a Changed Event is valid
     And the correlation-id is "Bad Request"
     When the Changed Event is sent for processing with "valid" api key
-    Then the "cr_dlq" logs show error message "Message Abandoned"
+    Then the Event "cr_dlq" shows field "error_msg" with message "Message Abandoned"
     And the Changed Event is stored in dynamo db
 
   @complete @dev @cloudwatch_queries
@@ -55,7 +55,7 @@ Feature: F004. Error Handling
   Scenario Outline: F004S008. An exception is raised when Sequence number is less than previous
     Given an ODS has an entry in dynamodb
     When the Changed Event is sent for processing with sequence id <seqid>
-    Then the event processor logs should record a sequence error
+    Then the Event "processor" shows field "message" with message "Sequence id is smaller than the existing one"
 
     Examples: These are both lower than the default sequence-id values
       | seqid |

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -354,10 +354,10 @@ def time_to_sec(t):
     return (h * 3600) + (m * 60)
 
 
-def generate_correlation_id(suffix=None) -> str:
+def generate_correlation_id(prefix=None) -> str:
     name_no_space = getenv("PYTEST_CURRENT_TEST").split(":")[-1].split(" ")[0].replace(" ", "_")
     run_id = getenv("RUN_ID")
-    correlation_id = f"{run_id}_{name_no_space}" if suffix is None else f"{run_id}_{suffix}"
+    correlation_id = f"{run_id}_{name_no_space}" if prefix is None else f"{prefix}_{run_id}"
     correlation_id = (
         correlation_id if len(correlation_id) < 80 else correlation_id[:79]
     )  # DoS API Gateway max reference is 100 characters


### PR DESCRIPTION
## Link to JIRA Ticket

- https://nhsd-jira.digital.nhs.uk/browse/DI-409

## Description

This ticket refactors a lot of the log checks within the test suite. They now use as few steps as possible to achieve this. 
There have, as a result, been several deleted steps.

All evidence of changed steps running succesfully is included in the ticket DI-409.

## Amendments

F002S001 Then to And
F002S001 - 
	the unmatched service exception is reported to cloudwatch
to 
	the Event "processor" shows field "message" with message "No matching DOS services"

F002S001 -
	no matched services were found
to
	the Event "processor" shows field "message" with message "Found 0 services in DB"

F002S001 - 
	the Changed Event is not processed any further
to
	the Event "processor" does not show "message" with message "Received change request"

F002S002 - 
	the hidden or closed exception is reported to cloudwatch
to
	the Event "processor" shows field "message" with message "NHS Service marked as closed or hidden"

F002S003 - 
	the Changed Event is not processed any further
	Same change as in F002S001

F002S004 - 
	the exception is reported to cloudwatch
to
	Note: This check just validates that there are no errors in the logs
	It is an Organisation Type ID ERROR that gets returned
	This test may require further updates with dentist org being sent

	the Event "processor" shows field "message" with message "Validation Error - Unexpected Org Type"

F002S004 - 
	the Changed Event is not processed any further
	Same change as in F002S001

F002S005 - 
	the exception is reported to cloudwatch
to
	the Event "processor" shows field "message" with message "Validation Error - Unexpected Org Sub Type ID"

F002S005 -
	the Changed Event is not procssed any further
	Same change as in F002S001

F002S006 -
	the invalid postcode exception is reported to cloudwatch
to
	the Event "processor" shows field "report_key" with message "INVALID_POSTCODE"

F002S008 -
	Note: This one has a strange check. We have since added a report_key for this. The existing check is quite nice because it verifies that the CR doesn't have times within, so I've just added another step.
Added:
	the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"

F002S009 - 
	Same as F002S008

F002S010 -
	Same as F002S008

F002S011 -
	Same as F002S010

F002S012 -
	Same as F002S010

F002S013 -
	Same as F002S010

F002S015 -
	an invalid opening times error is generated
to
	the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"

F002S016
	the unmatched service type exception is reported to cloudwatch
to
	the Event "processor" shows field "report_key" with message "UNMATCHED_SERVICE_TYPE"	

F002S017
	the generic bank holiday exception is reported to cloudwatch
to
	the Event "processor" shows field "report_key" with message "GENERIC_BANK_HOLIDAY"

F002S018
	the Event Processor logs with report key "HIDDEN_OR_CLOSED"
to
	the Event "processor" shows field "report_key" with message "HIDDEN_OR_CLOSED"			

F002S019
	the Event Processor logs with report key "INVALID_POSTCODE"
to
	the Event "processor" shows field "report_key" with message "INVALID_POSTCODE"	

F002S020
	the Event Processor logs with report key "INVALID_OPEN_TIMES"
to
	the Event "processor" shows field "report_key" with message "INVALID_OPEN_TIMES"

F002S021
	the Event Processor logs with report key "<report_key>"
to
	the Event "processor" shows field "report_key" with message "<report_key>"

F004S001
	the DLQ logs the error for Splunk
to
	the Event "cr_dlq" shows field "report_key" with message "CR_DLQ_HANDLER_RECEIVED_EVENT"

	the event is sent to the DLQ
to
	the Event "sender" shows field "response_text" with message "Fake Bad Request"	

	the "cr_dlq" logs show status code "400"
to
	the Event "cr_dlq" shows field "error_msg_http_code" with message "400"

F004S002
	the "cr_dlq" logs show error message "Message Abandoned"
to
	the Event "cr_dlq" shows field "error_msg" with message "Message Abandoned"	

F004S008
	the event processor logs should record a sequence error
to
	the Event "processor" shows field "message" with message "Sequence id is smaller than the existing one"


## Deletions

Step the unmatched service exception is reported to cloudwatch
Step the Changed Event is not processed any further
Step the hidden or closed exception is reported to cloudwatch
Step the exception is reported to cloudwatch
Step the invalid postcode exception is reported to cloudwatch
Step an invalid opening times error is generated
Step the unmatched service type exception is reported to cloudwatch
Step the Event Processor logs with report key ""
Step the "cr_dlq" logs show error message "Message Abandoned"
Step the "cr_dlq" logs show status code "400"
Step the DLQ logs the error for Splunk
Step the event processor logs should record a sequence error

### Noteworthy Changes

- These are changes the reviewer should look out for

## Type of change

Delete not appropriate

- Test

## Testing

Please tick the testing that has been completed

- [ ] Unit tests
- [x] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
