### PR TITLE
DI-358 Add org type info  to event replay logs

### DIFF
--- a/application/common/tests/test_dos.py
+++ b/application/common/tests/test_dos.py
@@ -39,7 +39,7 @@ def test_field_names():
         "modifiedtime",
         "publicphone",
         "publicname",
-        "servicename"
+        "servicename",
     ]
 
 

--- a/application/event_replay/event_replay.py
+++ b/application/event_replay/event_replay.py
@@ -36,6 +36,8 @@ def lambda_handler(event: Dict[str, Any], context: LambdaContext) -> str:
     logger.append_keys(ods_code=odscode)
     logger.append_keys(sequence_number=sequence_number)
     change_event = get_change_event(odscode, Decimal(sequence_number))
+    org_type_id = change_event.get("OrganisationTypeId")
+    logger.append_keys(org_type_id=org_type_id)
     send_change_event(change_event, odscode, int(sequence_number), correlation_id)
     return dumps({"message": "The change event has been re-sent successfully", "correlation_id": correlation_id})
 

--- a/application/event_replay/tests/test_event_replay.py
+++ b/application/event_replay/tests/test_event_replay.py
@@ -21,10 +21,7 @@ FILE_PATH = "application.event_replay.event_replay"
 
 @fixture
 def event() -> Dict[str, Any]:
-    return {
-        "odscode": "FXXX1",
-        "sequence_number": "1",
-    }
+    return {"odscode": "FXXX1", "sequence_number": "1"}
 
 
 @fixture


### PR DESCRIPTION
## Link to JIRA Ticket

- https://nhsd-jira.digital.nhs.uk/browse/DI-358

## Description

As per the current architecture dentist changed events will be stored as normal like pharmacy changed events for DLQ and replay purpose

### Noteworthy Changes

- Added missing org_type to event replay logs

## Type of change

- New feature (non-breaking change which adds functionality)

## Testing

Please tick the testing that has been completed

- [ ] Unit tests
- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
