### PR TITLE
DI-434 Change perf to use mock api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ restart: stop start # Restart project
 log: project-log # Show project logs
 
 deploy: # Deploys whole project - mandatory: PROFILE
-	if [ "$(PROFILE)" == "task" ] || [ "$(PROFILE)" == "dev" ]; then
+	if [ "$(PROFILE)" == "task" ] || [ "$(PROFILE)" == "dev" ] || [ "$(PROFILE)" == "perf" ]; then
 		make mock-dos-api-gateway-deployment
 	fi
 	eval "$$(make -s populate-deployment-variables)"

--- a/build/automation/var/profile/perf.mk
+++ b/build/automation/var/profile/perf.mk
@@ -9,7 +9,8 @@ DOS_API_GATEWAY_SECRETS = core-dos-db-sync/deployment
 DOS_API_GATEWAY_USERNAME_KEY := DOS_API_GATEWAY_USER
 DOS_API_GATEWAY_PASSWORD_KEY := DOS_API_GATEWAY_PASSWORD
 
-DOS_API_GATEWAY_URL := https://core-dos-performance-ddc-core-dos-api-gateway.k8s-nonprod.texasplatform.uk/api/change-request
+DOS_API_GATEWAY_URL := $(or $(DOS_API_GATEWAY_MOCK_URL), "//")
+# DOS_API_GATEWAY_URL := https://core-dos-performance-ddc-core-dos-api-gateway.k8s-nonprod.texasplatform.uk/api/change-request
 
 DB_SERVER_NAME := uec-core-dos-performance-db-12-replica-di
 DB_PORT := 5432

--- a/build/automation/var/profile/tools.mk
+++ b/build/automation/var/profile/tools.mk
@@ -18,7 +18,7 @@ TERRAFORM_NETWORKING_ROUTE53_ZONE_NAME = $(PROJECT_GROUP_SHORT).$(TEXAS_TLD_NAME
 TERRAFORM_NHSD_IDENTITIES_ACCOUNT_ID = $(AWS_ACCOUNT_ID_IDENTITIES)
 
 
-TF_VAR_code_pipeline_branch_name := master
+TF_VAR_code_pipeline_branch_name := develop
 TF_VAR_pipeline_topic_name := $(PROJECT_ID)-$(ENVIRONMENT)-pipeline-topic
 TF_VAR_pipeline_notification_name := $(PROJECT_ID)-$(ENVIRONMENT)-pipeline-notification
 TF_VAR_pipeline_chatbot_channel := $(PROJECT_ID)-cicd-slk-channel

--- a/build/automation/var/project.mk
+++ b/build/automation/var/project.mk
@@ -117,7 +117,7 @@ SQS_QUEUE_URL:= https://sqs.$(AWS_REGION).amazonaws.com/$(AWS_ACCOUNT_ID)/$(TF_V
 DOS_TRANSACTIONS_PER_SECOND=3
 
 # Performance Pipelines
-TF_VAR_code_pipeline_branch_name := master
+TF_VAR_code_pipeline_branch_name := develop
 TF_VAR_pipeline_topic_name := $(PROJECT_ID)-$(ENVIRONMENT)-pipeline-topic
 TF_VAR_pipeline_notification_name := $(PROJECT_ID)-$(ENVIRONMENT)-pipeline-notification
 TF_VAR_pipeline_chatbot_channel := $(PROJECT_ID)-cicd-slk-channel


### PR DESCRIPTION
## Link to JIRA Ticket

- https://nhsd-jira.digital.nhs.uk/browse/DI-434

## Description

The performance environment is a shared environment and we need to therefore arrange times when we apply load. As such we should set the performance test to run against Mock DOS by default and use this for our overnight performance tests and then update config when we have arranged a full end to end test to point to the real one.

### Noteworthy Changes

- Add mock into the deploy make for perf env and update env vars to point the event sender to the mock by default

## Type of change

Delete not appropriate


- New feature (non-breaking change which adds functionality)


## Testing

Please tick the testing that has been completed

- [ ] Unit tests
- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
