### PR TITLE
DI-439 Fix Automatic odscode selection bug

### DIFF
--- a/test/integration/steps/test_parent_steps.py
+++ b/test/integration/steps/test_parent_steps.py
@@ -123,7 +123,7 @@ def a_valid_changed_event_with_empty_contact(data, contact_field):
             return data
 
     context = {}
-    context["change_event"] = create_change_event("pharmacy")
+    context["change_event"] = build_same_as_dos_change_event("pharmacy")
     del context["change_event"]["Contacts"][0]["ContactValue"]
     del context["change_event"]["Contacts"][1]["ContactValue"]
     if "correlation_id" not in context:


### PR DESCRIPTION
## Link to JIRA Ticket

https://nhsd-jira.digital.nhs.uk/browse/DI-439

## Description

[DI-430](https://nhsd-jira.digital.nhs.uk/browse/DI-430) automates the selection of odscodes for test scenaarios. Some selected odscodes contain multiple services causing inconsistent test data being inputted into test steps.

This fix alters the payload by ensuring selected odscodes being injected into the step functions only contain a single service.

### Noteworthy Changes

- These are changes the reviewer should look out for

## Type of change

Delete not appropriate

- Bug fix (non-breaking change which fixes an issue)

## Testing

Please tick the testing that has been completed

- [ ] Unit tests
- [ ] Integration tests

## Developer Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have run the [code formatting checks](../README.md#code-quality)
- [ ] I have run the [code quality checks](../README.md#code-quality)
- [ ] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [ ] Unit test code coverage is at or above 80%
- [ ] New and existing unit tests pass locally with my changes
- [ ] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [ ] I have made corresponding changes to the documentation
- [ ] I have cleaned down my environment (if created)

## Code Reviewer Checklist

- [ ] I have run the unit tests and they run correctly
- [ ] I can confirm the changes have been tested or approved by a tester
- [ ] I can confirm no remaining infrastructure is left over from this branch
