### PR TITLE
DI-428 Add logging for change requests created

### DIFF
--- a/application/event_processor/event_processor.py
+++ b/application/event_processor/event_processor.py
@@ -109,7 +109,9 @@ class EventProcessor:
             changes = get_changes(service, self.nhs_entity)
             logger.info(f"Changes for nhs:{self.nhs_entity.odscode}/dos:{service.id} : {changes}")
             if len(changes) > 0:
-                change_requests.append(ChangeRequest(service.id, changes))
+                change_request = ChangeRequest(service.id, changes)
+                logger.info("Change Request Created", extra={"change_request": change_request})
+                change_requests.append(change_request)
 
         payload_list = dumps([cr.create_payload() for cr in change_requests], default=str)
         logger.info(f"Created {len(change_requests)} change requests {payload_list}")

--- a/application/event_sender/event_sender.py
+++ b/application/event_sender/event_sender.py
@@ -84,7 +84,7 @@ def lambda_handler(event: ChangeRequestQueueItem, context: LambdaContext, metric
             # No need to change the status of the circuit, it will remain open until a success
         else:
             # TODO: The current DoS Api returns 500 when it should return 400, this isn't ideal
-            # as it means we will circuit break unnecessarily and this could happen repeatidly until
+            # as it means we will circuit break unnecessarily and this could happen repeatedly until
             # the message is DLQ'd - 5 times, if we can fix that then these message could be sent to the dlq
             # and deleted to avoid circuit breaking and even replaying when we know it will fail again
             if response is None:


### PR DESCRIPTION
This is a log so that new CRs can be monitored.

This has passed unit tests when run