### PR TITLE
DI-451 Update Sonarcloud to include Serverless Framework and Terraform

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -29,10 +29,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         with:
-          projectBaseDir: ./application
+          projectBaseDir: .
           args: >
+            -Dsonar.sources=application,deployment,infrastructure
             -Dsonar.organization=nhsd-exeter
             -Dsonar.projectKey=uec-dos-int
-            -Dsonar.coverage.exclusions=tests/**,**/tests/**
+            -Dsonar.coverage.exclusions=tests/**,**/tests/**,deployment,infrastructure
             -Dsonar.python.coverage.reportPaths=coverage.xml
             -Dsonar.python.version=3.9


### PR DESCRIPTION
## Link to JIRA Ticket

- https://nhsd-jira.digital.nhs.uk/browse/DI-451
