### PR TITLE
Fix Performance Test Runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,7 +322,7 @@ plan-deployment-pipelines:
 		echo "PROFILE must be tools and ENVIRONMENT must be dev"
 	fi
 
-deploy-perf-test-tools:
+deploy-perf-test-tools: # Deploys perf test tools terraform stack - mandatory: ENVIRONMENT. Shared Development ENVIRONMENT is tools
 	make terraform-apply-auto-approve STACKS=perf-test-tools PROFILE=tools
 
 undeploy-perf-test-tools:

--- a/infrastructure/stacks/perf-test-tools/codebuild.tf
+++ b/infrastructure/stacks/perf-test-tools/codebuild.tf
@@ -45,7 +45,7 @@ resource "aws_codebuild_project" "di_performance_tests" {
     }
     environment_variable {
       name  = "ENVIRONMENT"
-      value = var.from_release_branch == true ? "${var.environment}-perf" : var.environment
+      value = var.from_release_branch == true ? "${var.environment}-perf" : "perf"
     }
     environment_variable {
       name  = "PERF_TEST_NAME"


### PR DESCRIPTION
# Task Branch Pull Request

## Description of Changes

This PR fixes the AWS Codebuild stage that runs the performance tests using the incorrect environment. So now it is pointed to `perf` rather than `tools`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the [code formatting checks](../README.md#code-quality)
- [x] I have run the [code quality checks](../README.md#code-quality)
- [x] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
