### PR TITLE
DI-477 Integration tests for past opening times

### DIFF
--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -171,3 +171,19 @@ Feature: F002. Invalid change event Exception handling
       | ods_code  |
       | V00393    |
       | V00393abc |
+
+@complete @dentist_cloudwatch_queries
+  Scenario Outline: F002S024. Dentist past specified opening time
+    Given a "dentist" Changed Event is aligned with Dos
+    And a specified opening time is set to "Jan 1 2022"
+    When the Changed Event is sent for processing with "valid" api key
+    Then the Event "processor" shows field "message" with message "Removing Specified opening times that occur in the past"
+    And the Event "processor" shows field "all_nhs.0" with message "CLOSED on 01-01-2022"
+
+@complete @pharmacy_cloudwatch_queries
+  Scenario Outline: F002S025. Pharmacy past specified opening time
+    Given a "pharmacy" Changed Event is aligned with Dos
+    And a specified opening time is set to "Jan 1 2022"
+    When the Changed Event is sent for processing with "valid" api key
+    Then the Event "processor" shows field "message" with message "Removing Specified opening times that occur in the past"
+    And the Event "processor" shows field "all_nhs.0" with message "CLOSED on 01-01-2022"

--- a/test/integration/steps/test_steps.py
+++ b/test/integration/steps/test_steps.py
@@ -163,6 +163,21 @@ def a_change_event_is_valid_with_contact_set(contact: str, context: Context):
     return context
 
 
+@given(parse('a specified opening time is set to "{selected_date}"'), target_fixture="context")
+def adjust_specified_opening_date(context: Context, selected_date: str):
+    additional_date = {
+        "Weekday": "",
+        "Times": "",
+        "OffsetOpeningTime": 0,
+        "OffsetClosingTime": 0,
+        "OpeningTimeType": "Additional",
+        "AdditionalOpeningDate": selected_date,
+        "IsOpen": False,
+    }
+    context.change_event.specified_opening_times.append(additional_date)
+    return context
+
+
 @given(parse('the field "{field}" is set to "{value}"'), target_fixture="context")
 def generic_event_config(context: Context, field: str, value: str):
     match field.lower():


### PR DESCRIPTION
This is an update for the opening times changes made in DI-472.

There are 2 new tests, 1 for dentists, 1 for pharmacies.
The tests consist of a log check for the new removed value.

It is not possible to add tests to verify the event sender has removed these values, since the event sender may not be populated with any information if there are no other changes made, and the only change was ignored.

Tests have been run on the DI-472 environment.

The all_nhs field is always a list object containing strings, so the test verifying all_nhs.0 will always find the value, as there are never any sub arrays to be checked. The Log Insights query automatically names the field all_nhs.0.