### PR TITLE
Add DoS API Gateway mock lambdas back into release pipeline

### DIFF
--- a/infrastructure/stacks/release-pipeline/data.tf
+++ b/infrastructure/stacks/release-pipeline/data.tf
@@ -17,5 +17,5 @@ data "aws_sns_topic" "development_pipeline_topic" {
 
 locals {
   deploy_envs = toset(["test", "perf"])
-  to_build    = toset(["event-sender", "event-processor", "fifo-dlq-handler", "orchestrator", "cr-fifo-dlq-handler", "test-db-checker-handler", "event-replay", "slack-messenger"])
+  to_build    = toset(["event-sender", "event-processor", "fifo-dlq-handler", "orchestrator", "cr-fifo-dlq-handler", "test-db-checker-handler", "event-replay", "slack-messenger", "authoriser", "dos-api-gateway"])
 }


### PR DESCRIPTION
This PR is to add the mock lambdas back into the release pipeline which is now needed by the performance environment by default