### PR TITLE
DI-518 Fix deleting security group

### DIFF
--- a/build/automation/var/project.mk
+++ b/build/automation/var/project.mk
@@ -43,7 +43,7 @@ TF_VAR_api_gateway_api_key_name := $(PROJECT_ID)-$(ENVIRONMENT)-api-key
 TF_VAR_nhs_uk_api_key_key := NHS_UK_API_KEY
 
 # Lambda Security Group
-TF_VAR_lambda_security_group_name := $(PROJECT_ID)-$(ENVIRONMENT)-lambda-db-sg
+TF_VAR_lambda_security_group_name := $(PROJECT_ID)-$(ENVIRONMENT)-lambda-sg
 
 # DI Endpoint API Gateway Route53 & SQS
 TF_VAR_dos_integration_sub_domain_name := $(PROGRAMME)-$(TEAM_ID)-$(ENVIRONMENT)


### PR DESCRIPTION
This PR is to fix a bug in DI-518 where it tries to rebuild the security group but the deletion fails. So putting back the old security group name it doesn't have to rebuild the security group