### PR TITLE
DI-560 Service history checks for integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[comple
 	echo RUN_ID=$$RUN_ID
 	make -s docker-run-tools \
 	IMAGE=$$(make _docker-get-reg)/tester:latest \
-	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json --reruns 2 --reruns-delay 60" \
+	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json" \
 	DIR=./test/integration \
 	ARGS=" \
 		-e API_KEY_SECRET=$(TF_VAR_api_gateway_api_key_name) \

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[comple
 	echo RUN_ID=$$RUN_ID
 	make -s docker-run-tools \
 	IMAGE=$$(make _docker-get-reg)/tester:latest \
-	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json" \
+	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json --reruns 2 --reruns-delay 60" \
 	DIR=./test/integration \
 	ARGS=" \
 		-e API_KEY_SECRET=$(TF_VAR_api_gateway_api_key_name) \

--- a/test/integration/features/F001_Valid_Change_Events.feature
+++ b/test/integration/features/F001_Valid_Change_Events.feature
@@ -14,6 +14,7 @@ Feature: F001. Ensure valid change events are converted and sent to DOS
     Given a "pharmacy" Changed Event is aligned with DoS
     When the Changed Event is sent for processing with "valid" api key
     Then the "service-sync" lambda shows field "message" with message "No changes to save"
+    And the service history is not updated
 
   @complete @pharmacy_no_log_searches
   Scenario Outline: F001S003. A valid change event with changed field is processed and captured by DOS
@@ -22,6 +23,7 @@ Feature: F001. Ensure valid change events are converted and sent to DOS
     When the Changed Event is sent for processing with "valid" api key
     Then the "<field>" is updated within the DoS DB
     And the service history is updated with the "<field>"
+    And the service history shows change type is "modify"
 
     Examples:
       | field    |

--- a/test/integration/features/F001_Valid_Change_Events.feature
+++ b/test/integration/features/F001_Valid_Change_Events.feature
@@ -1,12 +1,13 @@
 Feature: F001. Ensure valid change events are converted and sent to DOS
 
-  @complete @pharmacy_smoke_test @pharmacy_no_log_searches
+  @complete @pharmacy_smoke_test @pharmacy_no_log_searches @kit
   Scenario: F001S001. A valid change event is processed and accepted by DOS
     Given a "pharmacy" Changed Event is aligned with DoS
     And the field "Postcode" is set to "CT1 1AA"
     When the Changed Event is sent for processing with "valid" api key
     Then the "Postcode" is updated within the DoS DB
     And the service history is updated with the "Postcode"
+    And the service history shows change type is "modify"
 
   @complete @dev @pharmacy_cloudwatch_queries
   Scenario: F001S002. A Changed event with aligned data does not save an update to DoS

--- a/test/integration/features/F001_Valid_Change_Events.feature
+++ b/test/integration/features/F001_Valid_Change_Events.feature
@@ -1,6 +1,6 @@
 Feature: F001. Ensure valid change events are converted and sent to DOS
 
-  @complete @pharmacy_smoke_test @pharmacy_no_log_searches @kit
+  @complete @pharmacy_smoke_test @pharmacy_no_log_searches
   Scenario: F001S001. A valid change event is processed and accepted by DOS
     Given a "pharmacy" Changed Event is aligned with DoS
     And the field "Postcode" is set to "CT1 1AA"

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -22,6 +22,7 @@ Feature: F002. Invalid change event Exception handling
     And the field "OrganisationStatus" is set to "Closed"
     When the Changed Event is sent for processing with "valid" api key
     Then the "service-matcher" lambda shows field "report_key" with message "HIDDEN_OR_CLOSED"
+    And the service history is not updated
 
   @complete @dev @pharmacy_cloudwatch_queries
   Scenario: F002S004. A Changed Event where OrganisationTypeID is NOT PHA or Dentist is reported and ignored
@@ -29,6 +30,7 @@ Feature: F002. Invalid change event Exception handling
     And the field "OrganisationTypeId" is set to "DEN"
     When the Changed Event is sent for processing with "valid" api key
     Then the "service-matcher" lambda shows field "message" with message "Validation Error - Unexpected Org Type ID: 'DEN'"
+    And the service history is not updated
 
   @complete @dev @pharmacy_cloudwatch_queries
   Scenario: F002S005. A Changed Event where OrganisationSubType is NOT Community is reported and ignored
@@ -72,6 +74,7 @@ Feature: F002. Invalid change event Exception handling
     When the OpeningTimes Opening and Closing Times data are not defined
     And the Changed Event is sent for processing with "valid" api key
     Then the "service-sync" lambda shows field "message" with message "Opening times are not valid"
+    And the service history is not updated
 
   @complete @dev @pharmacy_cloudwatch_queries
   Scenario: F002S011. IsOpen is false AND Times NOT blank
@@ -107,6 +110,7 @@ Feature: F002. Invalid change event Exception handling
     And the field "ODSCode" is set to "TP68G"
     When the Changed Event is sent for processing with "valid" api key
     Then the "service-matcher" lambda shows field "report_key" with message "UNMATCHED_SERVICE_TYPE"
+    And the service history is not updated
 
   @complete @dev @pharmacy_cloudwatch_queries
   Scenario: F002S017. Pharmacies with generic bank holidays are reported in logs.

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -8,7 +8,7 @@ Feature: F002. Invalid change event Exception handling
     Then the "service-matcher" lambda shows field "message" with message "Found 0 services in DB"
     And the "service-matcher" lambda shows field "message" with message "No matching DOS services"
 
-  @complete @dev @pharmacy_cloudwatch_queries @kit
+  @complete @dev @pharmacy_cloudwatch_queries
   Scenario: F002S002. Changed Event with Hidden Organisation status is reported
     Given a "pharmacy" Changed Event is aligned with DoS
     And the field "OrganisationStatus" is set to "Hidden"

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -8,12 +8,13 @@ Feature: F002. Invalid change event Exception handling
     Then the "service-matcher" lambda shows field "message" with message "Found 0 services in DB"
     And the "service-matcher" lambda shows field "message" with message "No matching DOS services"
 
-  @complete @dev @pharmacy_cloudwatch_queries
+  @complete @dev @pharmacy_cloudwatch_queries @kit
   Scenario: F002S002. Changed Event with Hidden Organisation status is reported
     Given a "pharmacy" Changed Event is aligned with DoS
     And the field "OrganisationStatus" is set to "Hidden"
     When the Changed Event is sent for processing with "valid" api key
     Then the "service-matcher" lambda shows field "message" with message "NHS Service marked as closed or hidden"
+    And the service history is not updated
 
   @complete @dev @pharmacy_cloudwatch_queries
   Scenario: F002S003. Changed Event with Closed Organisation status is not processed

--- a/test/integration/steps/test_steps.py
+++ b/test/integration/steps/test_steps.py
@@ -24,6 +24,7 @@ from .utilities.translation import get_service_table_field_name
 from .utilities.utils import (
     check_received_data_in_dos,
     check_service_history,
+    check_service_history_change_type,
     confirm_approver_status,
     confirm_changes,
     generate_correlation_id,
@@ -47,6 +48,7 @@ from .utilities.utils import (
     remove_opening_days,
     service_not_updated,
     slack_retry,
+    service_history_negative_check,
     wait_for_service_update,
 )
 
@@ -613,6 +615,22 @@ def check_the_service_history_has_updated(context: Context, plain_english_servic
         expected_data=expected_data,
         previous_data=context.previous_value,
     )
+    return context
+
+
+@then(parse("the service history is not updated"))
+def check_service_history_not_updated(
+    context: Context,
+):
+    service_history_status = service_history_negative_check(context.service_id)
+    assert service_history_status == "Not Updated", "ERROR: Service history was unexpectedly updated"
+    return context
+
+
+@then(parse('the service history shows change type is "{change_type}"'))
+def check_service_history_for_change_type(context: Context, change_type: str):
+    change_status = check_service_history_change_type(context.service_id, change_type)
+    assert change_status == "Change type matches", f"ERROR: Expected {change_type} but {change_status}"
     return context
 
 

--- a/test/integration/steps/test_steps.py
+++ b/test/integration/steps/test_steps.py
@@ -46,9 +46,9 @@ from .utilities.utils import (
     process_payload_with_sequence,
     re_process_payload,
     remove_opening_days,
+    service_history_negative_check,
     service_not_updated,
     slack_retry,
-    service_history_negative_check,
     wait_for_service_update,
 )
 

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -405,7 +405,10 @@ def check_service_history_change_type(service_id: str, change_type: str):
         if change_status == change_type:
             return "Change type matches"
         elif change_type == "modify" and change_status == "add":
-            return "Change type matches"
+            if len(list(service_history.keys())) <= 1:
+                return "Change type matches"
+            else:
+                return "Change type does not match"
         else:
             return "Change type does not match"
     else:

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -385,18 +385,23 @@ def check_service_history(
 
 def service_history_negative_check(service_id: str):
     service_history = get_service_history(service_id)
-    first_key_in_service_history = list(service_history.keys())[0]
-    if check_recent_event(first_key_in_service_history):
+    if service_history == []:
         return "Not Updated"
     else:
-        return "Updated"
+        first_key_in_service_history = list(service_history.keys())[0]
+        if check_recent_event(first_key_in_service_history):
+            return "Not Updated"
+        else:
+            return "Updated"
 
 
 def check_service_history_change_type(service_id: str, change_type: str):
     service_history = get_service_history(service_id)
     first_key_in_service_history = list(service_history.keys())[0]
-    change_status = service_history[first_key_in_service_history]["new"]
-    [list(service_history[first_key_in_service_history]["new"].keys())[0]]
+    change_status = (
+        service_history[first_key_in_service_history]["new"][list(service_history[first_key_in_service_history]
+        ["new"].keys())[0]]["changetype"]
+        )
     if check_recent_event(first_key_in_service_history):
         if change_status == change_type:
             return "Change type matches"
@@ -417,7 +422,10 @@ def get_service_history(service_id: str) -> Dict[str, Any]:
     lambda_payload = {"type": "get_service_history", "service_id": service_id}
     response = invoke_dos_db_handler_lambda(lambda_payload)
     data = loads(loads(response))
-    return loads(data[0][0])
+    if data != []:
+        return loads(data[0][0])
+    else:
+        return []
 
 
 def check_received_data_in_dos(corr_id: str, search_key: str, search_param: str) -> bool:

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -398,9 +398,9 @@ def service_history_negative_check(service_id: str):
 def check_service_history_change_type(service_id: str, change_type: str):
     service_history = get_service_history(service_id)
     first_key_in_service_history = list(service_history.keys())[0]
-    change_status = service_history[first_key_in_service_history]["new"][
+    change_status = (service_history[first_key_in_service_history]["new"][
         list(service_history[first_key_in_service_history]["new"].keys())[0]
-    ]["changetype"]
+        ]["changetype"])
     if check_recent_event(first_key_in_service_history):
         if change_status == change_type:
             return "Change type matches"

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -398,10 +398,9 @@ def service_history_negative_check(service_id: str):
 def check_service_history_change_type(service_id: str, change_type: str):
     service_history = get_service_history(service_id)
     first_key_in_service_history = list(service_history.keys())[0]
-    change_status = (
-        service_history[first_key_in_service_history]["new"][list(service_history[first_key_in_service_history]
-        ["new"].keys())[0]]["changetype"]
-        )
+    change_status = service_history[first_key_in_service_history]["new"][
+        list(service_history[first_key_in_service_history]["new"].keys())[0]
+    ]["changetype"]
     if check_recent_event(first_key_in_service_history):
         if change_status == change_type:
             return "Change type matches"

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -386,8 +386,7 @@ def check_service_history(
 def service_history_negative_check(service_id: str):
     service_history = get_service_history(service_id)
     first_key_in_service_history = list(service_history.keys())[0]
-    currenttime = str(time() - 600)
-    if first_key_in_service_history <= currenttime:
+    if check_recent_event(first_key_in_service_history):
         return "Not Updated"
     else:
         return "Updated"
@@ -396,16 +395,22 @@ def service_history_negative_check(service_id: str):
 def check_service_history_change_type(service_id: str, change_type: str):
     service_history = get_service_history(service_id)
     first_key_in_service_history = list(service_history.keys())[0]
-    current = str(time() - 600)
     change_status = service_history[first_key_in_service_history]["new"]
     [list(service_history[first_key_in_service_history]["new"].keys())[0]]
-    if first_key_in_service_history <= current:
+    if check_recent_event(first_key_in_service_history):
         if change_status == change_type:
             return "Change type matches"
         else:
             return "Change type does not match"
     else:
         return "No changes have been made"
+
+
+def check_recent_event(event_time: str, time_difference=600) -> bool:
+    if str(time() - time_difference) <= event_time:
+        return True
+    else:
+        return False
 
 
 def get_service_history(service_id: str) -> Dict[str, Any]:

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -404,6 +404,8 @@ def check_service_history_change_type(service_id: str, change_type: str):
     if check_recent_event(first_key_in_service_history):
         if change_status == change_type:
             return "Change type matches"
+        elif change_type == "modify" and change_status == "add":
+            return "Change type matches"
         else:
             return "Change type does not match"
     else:
@@ -424,7 +426,7 @@ def get_service_history(service_id: str) -> Dict[str, Any]:
     if data != []:
         return loads(data[0][0])
     else:
-        return loads(data)
+        return data
 
 
 def check_received_data_in_dos(corr_id: str, search_key: str, search_param: str) -> bool:

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -398,9 +398,9 @@ def service_history_negative_check(service_id: str):
 def check_service_history_change_type(service_id: str, change_type: str):
     service_history = get_service_history(service_id)
     first_key_in_service_history = list(service_history.keys())[0]
-    change_status = (service_history[first_key_in_service_history]["new"][
+    change_status = service_history[first_key_in_service_history]["new"][
         list(service_history[first_key_in_service_history]["new"].keys())[0]
-        ]["changetype"])
+    ]["changetype"]
     if check_recent_event(first_key_in_service_history):
         if change_status == change_type:
             return "Change type matches"
@@ -424,7 +424,7 @@ def get_service_history(service_id: str) -> Dict[str, Any]:
     if data != []:
         return loads(data[0][0])
     else:
-        return []
+        return loads(data)
 
 
 def check_received_data_in_dos(corr_id: str, search_key: str, search_param: str) -> bool:

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -383,6 +383,31 @@ def check_service_history(
             raise ValueError(f"Input parameter '{previous_data}' not compatible")
 
 
+def service_history_negative_check(service_id: str):
+    service_history = get_service_history(service_id)
+    first_key_in_service_history = list(service_history.keys())[0]
+    currenttime = str(time() - 600)
+    if first_key_in_service_history <= currenttime:
+        return "Not Updated"
+    else:
+        return "Updated"
+
+
+def check_service_history_change_type(service_id: str, change_type: str):
+    service_history = get_service_history(service_id)
+    first_key_in_service_history = list(service_history.keys())[0]
+    current = str(time() - 600)
+    change_status = service_history[first_key_in_service_history]["new"]
+    [list(service_history[first_key_in_service_history]["new"].keys())[0]]
+    if first_key_in_service_history <= current:
+        if change_status == change_type:
+            return "Change type matches"
+        else:
+            return "Change type does not match"
+    else:
+        return "No changes have been made"
+
+
 def get_service_history(service_id: str) -> Dict[str, Any]:
     lambda_payload = {"type": "get_service_history", "service_id": service_id}
     response = invoke_dos_db_handler_lambda(lambda_payload)


### PR DESCRIPTION
# Test Branch Pull Request

## What branch do these tests check?

- DI-560. This is testing changes made in the DI-519 epic

## Description of changes/tests

Why do these tests need to exist?/When should the test be run?
These tests exists to validate specific changes in the newly implemented servicehistories table, as well as to ensure that no changes have been made to that table recently.

## Development Checklist

- [x] The tests are tagged correctly
- [x] The tests will be run in the development pipeline
- [x] The tests are stable and pass
- [x] I have used reusable functions and classes where possible

## Code Reviewer Checklist

- [x] I am confident the tests are stable and have passed
- [x] I am confident the tests will be run in the development pipeline
- [x] I believe the tests developed in a way which makes them reusable and maintainable