### PR TITLE
DI-558 Service history specified dates tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[comple
 	echo RUN_ID=$$RUN_ID
 	make -s docker-run-tools \
 	IMAGE=$$(make _docker-get-reg)/tester:latest \
-	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json --reruns 2 --reruns-delay 60" \
+	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json" \
 	DIR=./test/integration \
 	ARGS=" \
 		-e API_KEY_SECRET=$(TF_VAR_api_gateway_api_key_name) \

--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[comple
 	echo RUN_ID=$$RUN_ID
 	make -s docker-run-tools \
 	IMAGE=$$(make _docker-get-reg)/tester:latest \
-	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json" \
+	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json --reruns 2 --reruns-delay 60" \
 	DIR=./test/integration \
 	ARGS=" \
 		-e API_KEY_SECRET=$(TF_VAR_api_gateway_api_key_name) \

--- a/test/integration/features/F006_Opening_times.feature
+++ b/test/integration/features/F006_Opening_times.feature
@@ -1,10 +1,11 @@
 Feature: F006. Opening times
 
-  @complete @pharmacy_no_log_searches
+  @complete @pharmacy_no_log_searches @kit
   Scenario: F006S001. Confirm actual opening times change for specified date and time is captured by DoS
     Given an opened specified opening time Changed Event is valid
     When the Changed Event is sent for processing with "valid" api key
     Then the DoS service has been updated with the specified date and time is captured by DoS
+    And the service history is updated with the "added" specified opening times
 
   @complete @pharmacy_no_log_searches
   Scenario: F006S002. Confirm actual opening times change for standard date and time is captured by Dos
@@ -50,13 +51,14 @@ Feature: F006. Opening times
     When the Changed Event is sent for processing with "valid" api key
     Then the "service-sync" lambda does not show "report_key" with message "INVALID_OPEN_TIMES"
 
-  @complete @pharmacy_no_log_searches
+  @complete @pharmacy_no_log_searches @kit
   Scenario: F006S008. Confirm recently added specified opening date can be removed from Dos
     Given an opened specified opening time Changed Event is valid
     When the Changed Event is sent for processing with "valid" api key
     Then DoS is updated with the new specified opening times
     And the Changed Event is replayed with the specified opening date deleted
     And the deleted specified date is confirmed removed from DoS
+    And the service history is updated with the "removed" specified opening times
 
   @complete @pharmacy_no_log_searches
   Scenario: F006S009. A recently closed pharmacy on a standard day can be opened
@@ -85,10 +87,3 @@ Feature: F006. Opening times
       | opening_type |
       | General      |
       | Additional   |
-
-  @kit
-  Scenario: F006S012. Testing of the specified opening times checks
-    Given a "pharmacy" Changed Event is aligned with DoS
-    Given the Changed Event contains a specified opening date that is "open"
-    When the Changed Event is sent for processing with "valid" api key
-    Then the service history is updated with the specified opening times

--- a/test/integration/features/F006_Opening_times.feature
+++ b/test/integration/features/F006_Opening_times.feature
@@ -85,3 +85,10 @@ Feature: F006. Opening times
       | opening_type |
       | General      |
       | Additional   |
+
+  @kit
+  Scenario: F006S012. Testing of the specified opening times checks
+    Given a "pharmacy" Changed Event is aligned with DoS
+    Given the Changed Event contains a specified opening date that is "open"
+    When the Changed Event is sent for processing with "valid" api key
+    Then the service history is updated with the specified opening times

--- a/test/integration/features/F006_Opening_times.feature
+++ b/test/integration/features/F006_Opening_times.feature
@@ -1,6 +1,6 @@
 Feature: F006. Opening times
 
-  @complete @pharmacy_no_log_searches @kit
+  @complete @pharmacy_no_log_searches
   Scenario: F006S001. Confirm actual opening times change for specified date and time is captured by DoS
     Given an opened specified opening time Changed Event is valid
     When the Changed Event is sent for processing with "valid" api key
@@ -51,7 +51,7 @@ Feature: F006. Opening times
     When the Changed Event is sent for processing with "valid" api key
     Then the "service-sync" lambda does not show "report_key" with message "INVALID_OPEN_TIMES"
 
-  @complete @pharmacy_no_log_searches @kit
+  @complete @pharmacy_no_log_searches
   Scenario: F006S008. Confirm recently added specified opening date can be removed from Dos
     Given an opened specified opening time Changed Event is valid
     When the Changed Event is sent for processing with "valid" api key

--- a/test/integration/steps/test_steps.py
+++ b/test/integration/steps/test_steps.py
@@ -25,7 +25,6 @@ from .utilities.utils import (
     check_received_data_in_dos,
     check_service_history,
     check_service_history_change_type,
-    check_service_history_specified,
     confirm_approver_status,
     confirm_changes,
     convert_specified_opening,
@@ -37,6 +36,7 @@ from .utilities.utils import (
     get_expected_data,
     get_latest_sequence_id_for_a_given_odscode,
     get_odscode_with_contact_data,
+    get_service_history_specified_opening_times,
     get_service_id,
     get_service_table_field,
     get_stored_events_from_dynamo_db,
@@ -635,7 +635,7 @@ def check_service_history_specified_times(context: Context, added_or_removed):
         openingtimes = context.change_event.specified_opening_times[-1]
     if change_type == "remove":
         openingtimes = context.other
-    dos_times = check_service_history_specified(context.service_id)
+    dos_times = get_service_history_specified_opening_times(context.service_id)
     changed_dates = dos_times["data"][change_type]
     if added_or_removed == "closed":
         expected_dates = convert_specified_opening(openingtimes, True)

--- a/test/integration/steps/test_steps.py
+++ b/test/integration/steps/test_steps.py
@@ -25,8 +25,10 @@ from .utilities.utils import (
     check_received_data_in_dos,
     check_service_history,
     check_service_history_change_type,
+    check_service_history_specified,
     confirm_approver_status,
     confirm_changes,
+    convert_specified_opening,
     generate_correlation_id,
     generate_random_int,
     get_address_string,
@@ -615,6 +617,16 @@ def check_the_service_history_has_updated(context: Context, plain_english_servic
         expected_data=expected_data,
         previous_data=context.previous_value,
     )
+    return context
+
+
+@then(parse("the service history is updated with the specified opening times"))
+def check_service_history_specified_times(context: Context):
+    openingtimes = context.change_event.specified_opening_times[-1]
+    dos_times = check_service_history_specified(context.service_id)
+    changed_dates = dos_times["data"]["add"]
+    expected_dates = convert_specified_opening(openingtimes)
+    assert changed_dates == expected_dates, f"{expected_dates}"
     return context
 
 

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -421,13 +421,10 @@ def check_service_history_specified(service_id: str):
     return specified_open_times
 
 
-def convert_specified_opening(specified_date):
+def convert_specified_opening(specified_date, closed_status=False):
     # {'OpeningTime': '09:00', 'ClosingTime': '17:00', 'OpeningTimeType': 'Additional',
     #  'AdditionalOpeningDate': 'Dec 25 2025', 'IsOpen': True}
     # ['2025-12-15-32400-61200']
-    return_array = []
-    opening_time = time_to_seconds(specified_date["OpeningTime"])
-    closing_time = time_to_seconds(specified_date["ClosingTime"])
     months = {
         "Jan": "01",
         "Feb": "02",
@@ -444,8 +441,13 @@ def convert_specified_opening(specified_date):
     }
     split_date = specified_date["AdditionalOpeningDate"].split(" ")
     selected_month = months[split_date[0]]
-    return_array.insert(0, f"{split_date[2]}-{selected_month}-{split_date[1]}-{opening_time}-{closing_time}")
-    return return_array
+    if closed_status is False:
+        opening_time = time_to_seconds(specified_date["OpeningTime"])
+        closing_time = time_to_seconds(specified_date["ClosingTime"])
+        return_string = f"{split_date[2]}-{selected_month}-{split_date[1]}-{opening_time}-{closing_time}"
+    else:
+        return_string = f"{split_date[2]}-{selected_month}-{split_date[1]}-closed"
+    return return_string
 
 
 def time_to_seconds(time: str):

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -415,7 +415,7 @@ def check_service_history_change_type(service_id: str, change_type: str):
         return "No changes have been made"
 
 
-def check_service_history_specified(service_id: str) -> dict:
+def get_service_history_specified_opening_times(service_id: str) -> dict:
     # This function grabs the latest cmsopentimespecified object for a service id and returns it
     service_history = get_service_history(service_id)
     specified_open_times = service_history[list(service_history.keys())[0]]["new"]["cmsopentimespecified"]

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -416,7 +416,7 @@ def check_service_history_change_type(service_id: str, change_type: str):
 
 
 def get_service_history_specified_opening_times(service_id: str) -> dict:
-    # This function grabs the latest cmsopentimespecified object for a service id and returns it
+    """ This function grabs the latest cmsopentimespecified object for a service id and returns it """
     service_history = get_service_history(service_id)
     specified_open_times = service_history[list(service_history.keys())[0]]["new"]["cmsopentimespecified"]
     return specified_open_times

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -415,6 +415,46 @@ def check_service_history_change_type(service_id: str, change_type: str):
         return "No changes have been made"
 
 
+def check_service_history_specified(service_id: str):
+    service_history = get_service_history(service_id)
+    specified_open_times = service_history[list(service_history.keys())[0]]["new"]["cmsopentimespecified"]
+    return specified_open_times
+
+
+def convert_specified_opening(specified_date):
+    # {'OpeningTime': '09:00', 'ClosingTime': '17:00', 'OpeningTimeType': 'Additional',
+    #  'AdditionalOpeningDate': 'Dec 25 2025', 'IsOpen': True}
+    # ['2025-12-15-32400-61200']
+    return_array = []
+    opening_time = time_to_seconds(specified_date["OpeningTime"])
+    closing_time = time_to_seconds(specified_date["ClosingTime"])
+    months = {
+        "Jan": "01",
+        "Feb": "02",
+        "Mar": "03",
+        "Apr": "04",
+        "May": "05",
+        "Jun": "06",
+        "Jul": "07",
+        "Aug": "08",
+        "Sep": "09",
+        "Oct": "10",
+        "Nov": "11",
+        "Dec": "12",
+    }
+    split_date = specified_date["AdditionalOpeningDate"].split(" ")
+    selected_month = months[split_date[0]]
+    return_array.insert(0, f"{split_date[2]}-{selected_month}-{split_date[1]}-{opening_time}-{closing_time}")
+    return return_array
+
+
+def time_to_seconds(time: str):
+    times = time.split(":")
+    hour_seconds = int(times[0]) * 3600
+    minutes_seconds = int(times[1]) * 60
+    return str(hour_seconds + minutes_seconds)
+
+
 def check_recent_event(event_time: str, time_difference=600) -> bool:
     if str(time() - time_difference) <= event_time:
         return True
@@ -423,9 +463,14 @@ def check_recent_event(event_time: str, time_difference=600) -> bool:
 
 
 def get_service_history(service_id: str) -> Dict[str, Any]:
-    lambda_payload = {"type": "get_service_history", "service_id": service_id}
-    response = invoke_dos_db_handler_lambda(lambda_payload)
-    data = loads(loads(response))
+    data = []
+    retrycounter = 0
+    while data == [] and retrycounter < 5:
+        lambda_payload = {"type": "get_service_history", "service_id": service_id}
+        response = invoke_dos_db_handler_lambda(lambda_payload)
+        data = loads(loads(response))
+        retrycounter += 1
+        sleep(5)
     if data != []:
         return loads(data[0][0])
     else:

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -415,16 +415,17 @@ def check_service_history_change_type(service_id: str, change_type: str):
         return "No changes have been made"
 
 
-def check_service_history_specified(service_id: str):
+def check_service_history_specified(service_id: str) -> dict:
+    #This function grabs the latest cmsopentimespecified object for a service id and returns it
     service_history = get_service_history(service_id)
     specified_open_times = service_history[list(service_history.keys())[0]]["new"]["cmsopentimespecified"]
     return specified_open_times
 
 
-def convert_specified_opening(specified_date, closed_status=False):
-    # {'OpeningTime': '09:00', 'ClosingTime': '17:00', 'OpeningTimeType': 'Additional',
-    #  'AdditionalOpeningDate': 'Dec 25 2025', 'IsOpen': True}
-    # ['2025-12-15-32400-61200']
+def convert_specified_opening(specified_date, closed_status=False) -> str:
+    #Input standard specified opening times from Change Event
+    #Convert and output in the format:
+    #"dd-mm-yyyy-06000-12000"
     months = {
         "Jan": "01",
         "Feb": "02",

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -416,16 +416,22 @@ def check_service_history_change_type(service_id: str, change_type: str):
 
 
 def check_service_history_specified(service_id: str) -> dict:
-    #This function grabs the latest cmsopentimespecified object for a service id and returns it
+    # This function grabs the latest cmsopentimespecified object for a service id and returns it
     service_history = get_service_history(service_id)
     specified_open_times = service_history[list(service_history.keys())[0]]["new"]["cmsopentimespecified"]
     return specified_open_times
 
 
 def convert_specified_opening(specified_date, closed_status=False) -> str:
-    #Input standard specified opening times from Change Event
-    #Convert and output in the format:
-    #"dd-mm-yyyy-06000-12000"
+    """Converts opening times from CE format to DOS format
+
+    Args:
+        Specified opening dates from change event
+        Closed Status since output string changes if closed
+    Returns:
+        Converted opening dates/times in dos string format
+        "dd-mm-yyyy-06000-12000"
+    """
     months = {
         "Jan": "01",
         "Feb": "02",

--- a/test/integration/steps/utilities/utils.py
+++ b/test/integration/steps/utilities/utils.py
@@ -426,11 +426,10 @@ def convert_specified_opening(specified_date, closed_status=False) -> str:
     """Converts opening times from CE format to DOS format
 
     Args:
-        Specified opening dates from change event
-        Closed Status since output string changes if closed
+        specified_date (dict): Specified opening dates from change event
+        closed_status (bool): Closed Status since output string changes if closed
     Returns:
-        Converted opening dates/times in dos string format
-        "dd-mm-yyyy-06000-12000"
+        return_string (str): Converted opening dates/times in dos string format "dd-mm-yyyy-06000-12000"
     """
     months = {
         "Jan": "01",


### PR DESCRIPTION
# Test Branch Pull Request

## What branch do these tests check?

- DI-558 - Based off the DI-519 epic

## Description of changes/tests

Why do these tests need to exist?/When should the test be run?
These tests verify that the service history is updated for specified opening times changes.

## Development Checklist

- [x] The tests are tagged correctly
- [x] The tests will be run in the development pipeline
- [x] The tests are stable and pass
- [x] I have used reusable functions and classes where possible

## Code Reviewer Checklist

- [x] I am confident the tests are stable and have passed
- [x] I am confident the tests will be run in the development pipeline
- [x] I believe the tests developed in a way which makes them reusable and maintainable