### PR TITLE
DI-574 Allow Cloudwatch Alarms to read KMS Keys (Release 2.2) 

### DIFF
--- a/infrastructure/stacks/before-lambda-deployment/data.tf
+++ b/infrastructure/stacks/before-lambda-deployment/data.tf
@@ -41,4 +41,22 @@ data "aws_iam_policy_document" "kms_policy" {
     ]
     not_resources = []
   }
+  statement {
+    sid    = null
+    effect = "Allow"
+    principals {
+      identifiers = [
+        "cloudwatch.amazonaws.com"
+      ]
+      type = "Service"
+    }
+    actions = [
+      "kms:*"
+    ]
+    not_actions = []
+    resources = [
+      "*"
+    ]
+    not_resources = []
+  }
 }


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DI-574>**

## Description of Changes

This PR is to merge in the hotfix for release 2.2 to allow cloudwatch alarms to access the KMS keys. This fixes the bug where cloudwatch alarms aren't being displayed in slack due to the alarm not being able to access the KMS Key

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the [code formatting checks](../README.md#code-quality)
- [x] I have run the [code quality checks](../README.md#code-quality)
- [x] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester
- [x] I have checked any ignore commands for code linting tools and I agree that the code is safe