### PR TITLE
DI-583 Email Monitoring Alarm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ deploy: # Deploys whole project - mandatory: PROFILE
 
 undeploy: # Undeploys whole project - mandatory: PROFILE
 	make terraform-destroy-auto-approve STACKS=after-lambda-deployment
-	make serverless-remove VERSION="any" DB_PASSWORD="any" DB_SERVER="any" DB_USER_NAME="any" SLACK_WEBHOOK_URL="any" DB_READ_ONLY_USER_NAME="any" DB_READ_AND_WRITE_USER_NAME="any" DB_REPLICA_SERVER="any"
+	make serverless-remove VERSION="any" DB_PASSWORD="any" DB_SERVER="any" DB_USER_NAME="any" SLACK_WEBHOOK_URL="any" DB_READ_ONLY_USER_NAME="any" DB_READ_AND_WRITE_USER_NAME="any" DB_REPLICA_SERVER="any" PROJECT_TEAM_EMAIL_ADDRESS="any" DB_NAME="any" PROJECT_SYSTEM_EMAIL_ADDRESS="any"
 	make terraform-destroy-auto-approve STACKS=before-lambda-deployment,appconfig
 	if [ "$(PROFILE)" != "live" ]; then
 		make terraform-destroy-auto-approve STACKS=api-key

--- a/application/send_email/requirements.txt
+++ b/application/send_email/requirements.txt
@@ -1,1 +1,2 @@
+aws_embedded_metrics
 aws_lambda_powertools

--- a/application/send_email/send_email.py
+++ b/application/send_email/send_email.py
@@ -1,12 +1,12 @@
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from os import environ
-from smtplib import SMTP
+from smtplib import SMTP, SMTPException
 
 from aws_lambda_powertools.logging import Logger
 from aws_lambda_powertools.tracing import Tracer
 from aws_lambda_powertools.utilities.typing import LambdaContext
-
+from common.utilities import add_metric
 from common.middlewares import unhandled_exception_logging_hidden_event
 from common.secretsmanager import get_secret
 from common.types import EmailMessage
@@ -47,16 +47,24 @@ def send_email(email_address: str, html_content: str, subject: str, correlation_
     aws_account_name = environ["AWS_ACCOUNT_NAME"]
     if aws_account_name != "nonprod" or "email" in correlation_id:
         email_secrets = get_secret(environ["EMAIL_SECRET_NAME"])
-        to_email_address = email_secrets["DI_TEAM_MAILBOX_ADDRESS"] if "email" in correlation_id else email_address
+        to_email_address = email_address
         di_system_email_address = email_secrets["DI_SYSTEM_MAILBOX_ADDRESS"]
         di_system_email_password = email_secrets["DI_SYSTEM_MAILBOX_PASSWORD"]
         msg = MIMEMultipart("alternative")
         msg["Subject"] = subject
         msg.attach(MIMEText(html_content, "html"))
         logger.info("Sending email")
-        smtp = SMTP(host="smtp.office365.com", port=587, timeout=15)
-        smtp.ehlo()
-        smtp.starttls()
-        smtp.login(di_system_email_address, di_system_email_password)
-        smtp.sendmail(from_addr=di_system_email_address, to_addrs=[to_email_address], msg=msg.as_string())
-        smtp.quit()
+        try:
+            # Don't log any variables that contain PID or password
+            smtp = SMTP(host="smtp.office365.com", port=587, timeout=15)
+            smtp.ehlo()
+            smtp.starttls()
+            smtp.login(di_system_email_address, di_system_email_password)
+            smtp.sendmail(from_addr=di_system_email_address, to_addrs=[to_email_address], msg=msg.as_string())
+            smtp.quit()
+            logger.info("Email sent")
+            add_metric("EmailSent")  # type: ignore
+        except SMTPException as error:
+            logger.exception("Error sending email", extra={"error": error})
+            add_metric("EmailFailed")  # type: ignore
+            raise error

--- a/application/send_email/send_email.py
+++ b/application/send_email/send_email.py
@@ -6,10 +6,11 @@ from smtplib import SMTP, SMTPException
 from aws_lambda_powertools.logging import Logger
 from aws_lambda_powertools.tracing import Tracer
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from common.utilities import add_metric
+
 from common.middlewares import unhandled_exception_logging_hidden_event
 from common.secretsmanager import get_secret
 from common.types import EmailMessage
+from common.utilities import add_metric
 
 tracer = Tracer()
 logger = Logger()

--- a/application/send_email/tests/test_send_email.py
+++ b/application/send_email/tests/test_send_email.py
@@ -1,9 +1,10 @@
 from dataclasses import dataclass
 from os import environ
+from smtplib import SMTPException
 from unittest.mock import MagicMock, patch
 
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from pytest import fixture
+from pytest import fixture, raises
 
 from application.common.types import EmailMessage
 from application.send_email.send_email import lambda_handler, send_email
@@ -11,11 +12,15 @@ from application.send_email.send_email import lambda_handler, send_email
 FILE_PATH = "application.send_email.send_email"
 BUCKET = "bucket"
 KEY = "key"
+CORRELATION_ID = "correlation_id"
+RECIPIENT_EMAIL_ADDRESS = "recipient_email_address"
+EMAIL_BODY = "This is the email body"
+EMAIL_SUBJECT = "Subject of email"
 EVENT = EmailMessage(
-    correlation_id="correlation_id",
-    recipient_email_address="test@test.com",
-    email_body="This is the email body",
-    email_subject="Subject of email",
+    correlation_id=CORRELATION_ID,
+    recipient_email_address=RECIPIENT_EMAIL_ADDRESS,
+    email_body=EMAIL_BODY,
+    email_subject=EMAIL_SUBJECT,
 )
 
 
@@ -49,17 +54,16 @@ def test_lambda_handler(mock_send_email: MagicMock, lambda_context: LambdaContex
     )
 
 
+@patch(f"{FILE_PATH}.add_metric")
 @patch(f"{FILE_PATH}.MIMEMultipart")
 @patch(f"{FILE_PATH}.SMTP")
 @patch(f"{FILE_PATH}.get_secret")
-def test_send_email(mock_get_secret: MagicMock, mock_smtp: MagicMock, mock_mime_multipart: MagicMock):
+def test_send_email(
+    mock_get_secret: MagicMock, mock_smtp: MagicMock, mock_mime_multipart: MagicMock, add_metric: MagicMock
+):
     # Arrange
     environ["AWS_ACCOUNT_NAME"] = "test"
     environ["EMAIL_SECRET_NAME"] = secret_name = "mock_secret_name"
-    email_address = "test@test.com"
-    html_content = "This is the email body"
-    subject = "Subject of email"
-    correlation_id = "correlation_id"
     di_team_mailbox_address = "di_team_mailbox_address"
     di_system_mailbox_address = "di_system_mailbox_address"
     di_system_mailbox_password = "di_system_mailbox_password"
@@ -70,10 +74,10 @@ def test_send_email(mock_get_secret: MagicMock, mock_smtp: MagicMock, mock_mime_
     }
     # Act
     response = send_email(
-        email_address=email_address,
-        html_content=html_content,
-        subject=subject,
-        correlation_id=correlation_id,
+        email_address=RECIPIENT_EMAIL_ADDRESS,
+        html_content=EMAIL_BODY,
+        subject=EMAIL_SUBJECT,
+        correlation_id=CORRELATION_ID,
     )
     # Assert
     assert response is None
@@ -84,10 +88,11 @@ def test_send_email(mock_get_secret: MagicMock, mock_smtp: MagicMock, mock_mime_
     mock_smtp.return_value.login.assert_called_once_with(di_system_mailbox_address, di_system_mailbox_password)
     mock_smtp.return_value.sendmail.assert_called_once_with(
         from_addr=di_system_mailbox_address,
-        to_addrs=[email_address],
+        to_addrs=[RECIPIENT_EMAIL_ADDRESS],
         msg=mock_mime_multipart.return_value.as_string.return_value,
     )
     mock_smtp.return_value.quit.assert_called_once()
+    add_metric.assert_called_once_with("EmailSent")
     # Clean up
     del environ["AWS_ACCOUNT_NAME"]
     del environ["EMAIL_SECRET_NAME"]
@@ -99,16 +104,12 @@ def test_send_email(mock_get_secret: MagicMock, mock_smtp: MagicMock, mock_mime_
 def test_send_email_nonprod(mock_get_secret: MagicMock, mock_smtp: MagicMock, mock_mime_multipart: MagicMock):
     # Arrange
     environ["AWS_ACCOUNT_NAME"] = "nonprod"
-    email_address = "test@test.com"
-    html_content = "This is the email body"
-    subject = "Subject of email"
-    correlation_id = "correlation_id"
     # Act
     response = send_email(
-        email_address=email_address,
-        html_content=html_content,
-        subject=subject,
-        correlation_id=correlation_id,
+        email_address=RECIPIENT_EMAIL_ADDRESS,
+        html_content=EMAIL_BODY,
+        subject=EMAIL_SUBJECT,
+        correlation_id=CORRELATION_ID,
     )
     # Assert
     assert response is None
@@ -117,3 +118,44 @@ def test_send_email_nonprod(mock_get_secret: MagicMock, mock_smtp: MagicMock, mo
     mock_mime_multipart.assert_not_called()
     # Clean up
     del environ["AWS_ACCOUNT_NAME"]
+
+
+@patch(f"{FILE_PATH}.add_metric")
+@patch(f"{FILE_PATH}.MIMEMultipart")
+@patch(f"{FILE_PATH}.SMTP")
+@patch(f"{FILE_PATH}.get_secret")
+def test_send_email_exception(
+    mock_get_secret: MagicMock, mock_smtp: MagicMock, mock_mime_multipart: MagicMock, add_metric: MagicMock
+):
+    # Arrange
+    environ["AWS_ACCOUNT_NAME"] = "test"
+    environ["EMAIL_SECRET_NAME"] = secret_name = "mock_secret_name"
+    di_team_mailbox_address = "di_team_mailbox_address"
+    di_system_mailbox_address = "di_system_mailbox_address"
+    di_system_mailbox_password = "di_system_mailbox_password"
+    mock_get_secret.return_value = {
+        "DI_TEAM_MAILBOX_ADDRESS": di_team_mailbox_address,
+        "DI_SYSTEM_MAILBOX_ADDRESS": di_system_mailbox_address,
+        "DI_SYSTEM_MAILBOX_PASSWORD": di_system_mailbox_password,
+    }
+    mock_smtp.return_value.ehlo.side_effect = SMTPException("Test exception")
+    # Act
+    with raises(SMTPException):
+        send_email(
+            email_address=RECIPIENT_EMAIL_ADDRESS,
+            html_content=EMAIL_BODY,
+            subject=EMAIL_SUBJECT,
+            correlation_id=CORRELATION_ID,
+        )
+    # Assert
+    mock_get_secret.assert_called_once_with(secret_name)
+    mock_smtp.assert_called_once_with(host="smtp.office365.com", port=587, timeout=15)
+    mock_smtp.return_value.ehlo.assert_called_once()
+    mock_smtp.return_value.starttls.assert_not_called()
+    mock_smtp.return_value.login.assert_not_called()
+    mock_smtp.return_value.sendmail.assert_not_called()
+    mock_smtp.return_value.quit.assert_not_called()
+    add_metric.assert_called_once_with("EmailFailed")
+    # Clean up
+    del environ["AWS_ACCOUNT_NAME"]
+    del environ["EMAIL_SECRET_NAME"]

--- a/infrastructure/stacks/after-lambda-deployment/cloudwatch-alarms.tf
+++ b/infrastructure/stacks/after-lambda-deployment/cloudwatch-alarms.tf
@@ -247,3 +247,19 @@ resource "aws_cloudwatch_metric_alarm" "health_check_failures_alert" {
   statistic                 = "Sum"
   threshold                 = "2"
 }
+
+resource "aws_cloudwatch_metric_alarm" "high_number_of_failed_emails_alert" {
+  alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack.arn]
+  alarm_description         = "Alert for when DI is failing to send emails"
+  alarm_name                = "${var.project_id} | ${var.environment} | Failed Emails"
+  comparison_operator       = "GreaterThanOrEqualToThreshold"
+  datapoints_to_alarm       = "1"
+  dimensions                = { ENV = var.environment }
+  evaluation_periods        = "1"
+  insufficient_data_actions = []
+  metric_name               = "EmailFailed"
+  namespace                 = "UEC-DOS-INT"
+  period                    = "120" # 2 minutes
+  statistic                 = "Sum"
+  threshold                 = "1"
+}


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DI-583>**

## Description of Changes

This PR adds a cloudwatch alarm to alarm when an email to fail sends

## Type of change

- New feature (non-breaking change which adds functionality)

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the [code formatting checks](../README.md#code-quality)
- [x] I have run the [code quality checks](../README.md#code-quality)
- [x] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester
- [x] I have checked any ignore commands for code linting tools and I agree that the code is safe