### PR TITLE
DI-580 Disable Serverless Framework Rollback

### DIFF
--- a/deployment/serverless.yml
+++ b/deployment/serverless.yml
@@ -51,13 +51,13 @@ provider:
     POWERTOOLS_TRACER_CAPTURE_ERROR: true
     POWERTOOLS_TRACE_MIDDLEWARES: true
     LOG_LEVEL: ${env:LOG_LEVEL}
-
     IMAGE_VERSION: ${env:VERSION}
   logs:
     restApi:
       format: '{"requestTime":"$context.requestTime","requestId":"$context.requestId","httpMethod":"$context.httpMethod","path":"$context.path","resourcePath":"$context.resourcePath","status":"$context.status","responseLatency":"$context.responseLatency","xrayTraceId":"$context.xrayTraceId","integrationRequestId":"$context.integration.requestId","functionResponseStatus":"$context.integration.status","integrationLatency":"$context.integration.latency","integrationServiceStatus":"$context.integration.integrationStatus","ip":"$context.identity.sourceIp","userAgent":"$context.identity.userAgent"}'
   tracing:
     lambda: true
+  disableRollback: true
 
 plugins:
   - serverless-vpc-discovery


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DI-580>**

## Description of Changes

This PR is to disable rollback so that update can be rolled back using DI's rollback method or deploying an update over the top of the failed update. When a deployment fails the resource with causes the error won't deploy. This means that the previous deployed version continues to work.

After Green/Blue deployments this will only be useful in nonprod

## Type of change

- New feature (non-breaking change which adds functionality)

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the [code formatting checks](../README.md#code-quality)
- [x] I have run the [code quality checks](../README.md#code-quality)
- [x] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester
- [x] I have checked any ignore commands for code linting tools and I agree that the code is safe

## Integration Test Results
![image](https://user-images.githubusercontent.com/62281988/194868516-4c2f4d0b-eabe-434c-b592-5b6857181fce.png)
