### PR TITLE
DI-576 Deployment bucket objects encryption

### DIFF
--- a/deployment/serverless.yml
+++ b/deployment/serverless.yml
@@ -13,6 +13,9 @@ provider:
   deploymentBucket:
     blockPublicAccess: true
     skipPolicySetup: true
+    versioning: true
+    serverSideEncryption: aws:kms
+    sseKMSKeyId: ${env:TERRAFORM_KMS_KEY_ID}
   stackTags:
     BUILD_TIMESTAMP: ${env:VERSION}
     DataClassification: ${env:PROJECT_DATA_CLASSIFICATION}

--- a/infrastructure/stacks/before-lambda-deployment/outputs.tf
+++ b/infrastructure/stacks/before-lambda-deployment/outputs.tf
@@ -1,4 +1,4 @@
 output "kms_key_id" {
-  description = "The KMS key ID we just created"
-  value       = aws_kms_key.signing_key.id
+  description = "The KMS key arn we just created"
+  value       = aws_kms_key.signing_key.arn
 }


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DI-576>**

## Description of Changes

This PR turns on standard s3 encryption for the deployment bucket but also KMS key encryption for the objects within the bucket.

## Type of change

- New feature (non-breaking change which adds functionality)

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] I have run the [code formatting checks](../README.md#code-quality)
- [x] I have run the [code quality checks](../README.md#code-quality)
- [x] New code meets [standards](https://nhsd-confluence.digital.nhs.uk/display/DI/DI+Ways+of+Working) agreed by the team
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester
- [x] I have checked any ignore commands for code linting tools and I agree that the code is safe