### PR TITLE
Refactor Pull Request Workflow to Stop False Positives

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,6 +2,9 @@ name: "Check pull request title, branch name and commit message"
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+    branches-ignore:
+      - "dependabot/**"
+      - "release/**"
 jobs:
   check-pull-request:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Task Branch Pull Request

## Description of Changes

This PR changes the pull-request.yml workflow to not run when Dependabot opens a PR or on a release