### PR TITLE
DSUEC-47 Redact `Staff` key and value from change event

### DIFF
--- a/application/change_event_dlq_handler/change_event_dlq_handler.py
+++ b/application/change_event_dlq_handler/change_event_dlq_handler.py
@@ -6,12 +6,13 @@ from aws_lambda_powertools.utilities.typing.lambda_context import LambdaContext
 
 from common.constants import FIFO_DLQ_HANDLER_REPORT_ID
 from common.dynamodb import add_change_event_to_dynamodb
-from common.middlewares import unhandled_exception_logging, redact_staff_key_from_event
+from common.middlewares import redact_staff_key_from_event, unhandled_exception_logging
 from common.utilities import extract_body, get_sequence_number, get_sqs_msg_attribute, handle_sqs_msg_attributes
 
 TTL = 157680000  # int((365*5)*24*60*60) . 5 years in seconds
 tracer = Tracer()
 logger = Logger()
+
 
 @redact_staff_key_from_event()
 @unhandled_exception_logging()

--- a/application/change_event_dlq_handler/change_event_dlq_handler.py
+++ b/application/change_event_dlq_handler/change_event_dlq_handler.py
@@ -6,14 +6,14 @@ from aws_lambda_powertools.utilities.typing.lambda_context import LambdaContext
 
 from common.constants import FIFO_DLQ_HANDLER_REPORT_ID
 from common.dynamodb import add_change_event_to_dynamodb
-from common.middlewares import unhandled_exception_logging
+from common.middlewares import unhandled_exception_logging, redact_staff_key_from_event
 from common.utilities import extract_body, get_sequence_number, get_sqs_msg_attribute, handle_sqs_msg_attributes
 
 TTL = 157680000  # int((365*5)*24*60*60) . 5 years in seconds
 tracer = Tracer()
 logger = Logger()
 
-
+@redact_staff_key_from_event()
 @unhandled_exception_logging()
 @tracer.capture_lambda_handler()
 @event_source(data_class=SQSEvent)

--- a/application/change_event_dlq_handler/tests/test_change_event_dlq_handler.py
+++ b/application/change_event_dlq_handler/tests/test_change_event_dlq_handler.py
@@ -7,14 +7,22 @@ from aws_embedded_metrics.logger.metrics_logger import MetricsLogger
 from pytest import fixture
 
 from ..change_event_dlq_handler import lambda_handler
-from common.tests.conftest import PHARMACY_STANDARD_EVENT
+from common.tests.conftest import PHARMACY_STANDARD_EVENT, PHARMACY_STANDARD_EVENT_STAFF
 
 FILE_PATH = "application.change_event_dlq_handler.change_event_dlq_handler"
-
 
 CHANGE_EVENT_FROM_CHANGE_EVENT_QUEUE = PHARMACY_STANDARD_EVENT.copy()
 CHANGE_EVENT_FROM_HOLDING_QUEUE = {
     "change_event": CHANGE_EVENT_FROM_CHANGE_EVENT_QUEUE,
+    "dynamo_record_id": "123456789",
+    "message_received": "2021-01-01T00:00:00.000000Z",
+    "sequence_number": "123456789",
+    "correlation_id": "123456789",
+}
+
+STAFF_CHANGE_EVENT_FROM_CHANGE_EVENT_QUEUE = PHARMACY_STANDARD_EVENT_STAFF.copy()
+STAFF_CHANGE_EVENT_FROM_HOLDING_QUEUE = {
+    "change_event": STAFF_CHANGE_EVENT_FROM_CHANGE_EVENT_QUEUE,
     "dynamo_record_id": "123456789",
     "message_received": "2021-01-01T00:00:00.000000Z",
     "sequence_number": "123456789",
@@ -30,6 +38,43 @@ def dead_letter_change_event_from_change_event_queue():
                 "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
                 "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
                 "body": dumps(CHANGE_EVENT_FROM_CHANGE_EVENT_QUEUE),
+                "attributes": {
+                    "ApproximateReceiveCount": "1",
+                    "SentTimestamp": "1545082649183",
+                    "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+                    "ApproximateFirstReceiveTimestamp": "1545082649185",
+                },
+                "messageAttributes": {
+                    "correlation-id": {
+                        "stringValue": "059f36b4-87a3-44ab-83d2-661975830a7d",
+                        "stringListValues": [],
+                        "binaryListValues": [],
+                        "dataType": "String",
+                    },
+                    "sequence-number": {
+                        "stringValue": "123456789",
+                        "stringListValues": [],
+                        "binaryListValues": [],
+                        "dataType": "String",
+                    },
+                },
+                "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+                "eventSource": "aws:sqs",
+                "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+                "awsRegion": "us-east-2",
+            }
+        ]
+    }
+
+
+@fixture
+def dead_letter_staff_change_event_from_change_event_queue():
+    yield {
+        "Records": [
+            {
+                "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
+                "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+                "body": dumps(STAFF_CHANGE_EVENT_FROM_CHANGE_EVENT_QUEUE),
                 "attributes": {
                     "ApproximateReceiveCount": "1",
                     "SentTimestamp": "1545082649183",
@@ -106,13 +151,15 @@ def test_lambda_handler_event_from_change_event_queue(
     mock_set_dimensions: MagicMock,
     mock_add_change_event_to_dynamodb: MagicMock,
     mock_extract_body: MagicMock,
+    dead_letter_staff_change_event_from_change_event_queue: Dict[str, Any],
     dead_letter_change_event_from_change_event_queue: Dict[str, Any],
     lambda_context,
 ):
-    # Arrang
+    # Arrange
     mock_extract_body.return_value = extracted_body = "Test message1."
     # Act
-    lambda_handler(dead_letter_change_event_from_change_event_queue, lambda_context)
+    assert "Staff" in dead_letter_staff_change_event_from_change_event_queue["Records"][0]["body"]
+    lambda_handler(dead_letter_staff_change_event_from_change_event_queue, lambda_context)
     # Assert
     mock_extract_body.assert_called_once_with(dead_letter_change_event_from_change_event_queue["Records"][0]["body"])
     expected_timestamp = int(

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -23,19 +23,23 @@ def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext
 
 @lambda_handler_decorator(trace_execution=True)
 def unhandled_exception_logging(handler, event, context: LambdaContext):
+    if isinstance(event, SQSEvent):
+        raw_event = event.raw_event
+    raw_event = event
+
     try:
         response = handler(event, context)
         return response
     except ValidationException as err:
-        logger.exception(f"Validation Error - {err}", extra={"error": err, "event": event})
+        logger.exception(f"Validation Error - {err}", extra={"error": err, "event": raw_event})
         return
     except ClientError as err:
         error_code = err.response["Error"]["Code"]
         error_msg = err.response["Error"]["Message"]
-        logger.exception(f"Boto3 Client Error - '{error_code}': {error_msg}", extra={"error": err, "event": event})
+        logger.exception(f"Boto3 Client Error - '{error_code}': {error_msg}", extra={"error": err, "event": raw_event})
         raise err
     except BaseException as err:
-        logger.exception(f"Something went wrong - {err}", extra={"error": err, "event": event})
+        logger.exception(f"Something went wrong - {err}", extra={"error": err, "event": raw_event})
         raise err
 
 

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -11,7 +11,7 @@ logger = Logger(child=True)
 
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event, context: LambdaContext):
-    logger.info(f"Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
+    logger.info(f"Checking if 'Staff' key needs removing from Change Event payload")
     if 'Records' in event and len(list(event['Records'])) > 0:
             for record in event['Records']:
                 change_event = extract_body(record['body'])

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -9,7 +9,6 @@ logger = Logger(child=True)
 
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event, context: LambdaContext):
-
     if 'records' in event and len(list(event.records)) > 0:
             for record in event.records:
                 if record.pop('Staff', None) != None:

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -11,9 +11,9 @@ logger = Logger(child=True)
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext):
     logger.info(f"Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
-    if 'Records' in event and len(list(event['Records'])) > 0:
-            for record in event['Records']:
-                if record['body'].pop('Staff', None) != None:
+    if len(list(event.records)) > 0:
+            for record in event.records:
+                if record.pop('Staff', None) != None:
                     logger.info("Redacted 'Staff' key from Change Event payload")
     return handler(event, context)
 

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -1,7 +1,6 @@
 from aws_lambda_powertools.logging import Logger
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from aws_lambda_powertools.utilities.data_classes import event_source, SQSEvent
 from botocore.exceptions import ClientError
 
 from common.errors import ValidationException
@@ -11,7 +10,7 @@ logger = Logger(child=True)
 
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event, context: LambdaContext):
-    logger.info(f"Checking if 'Staff' key needs removing from Change Event payload")
+    logger.info("Checking if 'Staff' key needs removing from Change Event payload")
     if 'Records' in event and len(list(event['Records'])) > 0:
             for record in event['Records']:
                 change_event = extract_body(record['body'])
@@ -22,7 +21,6 @@ def redact_staff_key_from_event(handler, event, context: LambdaContext):
 
 @lambda_handler_decorator(trace_execution=True)
 def unhandled_exception_logging(handler, event, context: LambdaContext):
-
     try:
         response = handler(event, context)
         return response

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -1,6 +1,7 @@
 from aws_lambda_powertools.logging import Logger
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
 from aws_lambda_powertools.utilities.typing import LambdaContext
+from aws_lambda_powertools.utilities.data_classes import event_source, SQSEvent
 from botocore.exceptions import ClientError
 
 from common.errors import ValidationException
@@ -8,12 +9,12 @@ from common.errors import ValidationException
 logger = Logger(child=True)
 
 @lambda_handler_decorator(trace_execution=True)
-def redact_staff_key_from_event(handler, event, context: LambdaContext):
-    logger.info("Checking if 'Staff' key needs removing from Change Event payload")
-    if 'Records' in event and len(list(event['Records'])) > 0:
-            for record in event['Records']:
-                if record['body'].pop('Staff', None) != None:
-                    logger.info("Redacted 'Staff' key from Change Event payload")
+def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext):
+    logger.info("Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
+    # if 'Records' in event and len(list(event['Records'])) > 0:
+    #         for record in event['Records']:
+    #             if record['body'].pop('Staff', None) != None:
+    #                 logger.info("Redacted 'Staff' key from Change Event payload")
     return handler(event, context)
 
 

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -5,6 +5,7 @@ from aws_lambda_powertools.utilities.data_classes import event_source, SQSEvent
 from botocore.exceptions import ClientError
 
 from common.errors import ValidationException
+from common.utilities import extract_body, json_str_body
 
 logger = Logger(child=True)
 
@@ -13,7 +14,9 @@ def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext
     logger.info(f"Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
     if len(list(event.records)) > 0:
             for record in event.records:
-                if record.pop('Staff', None) != None:
+                change_event = extract_body(record)
+                if change_event.pop('Staff', None) != None:
+                    record = json_str_body(change_event)
                     logger.info("Redacted 'Staff' key from Change Event payload")
     return handler(event, context)
 

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -24,7 +24,8 @@ def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext
 @lambda_handler_decorator(trace_execution=True)
 def unhandled_exception_logging(handler, event, context: LambdaContext):
     if isinstance(event, SQSEvent):
-        raw_event = event.raw_event
+        # raw_event = event.raw_event
+        raw_event = str(event)
     else:
         raw_event = event
 

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -8,16 +8,18 @@ from common.utilities import extract_body, json_str_body
 
 logger = Logger(child=True)
 
+
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event, context: LambdaContext):
     logger.info("Checking if 'Staff' key needs removing from Change Event payload")
     if 'Records' in event and len(list(event['Records'])) > 0:
-            for record in event['Records']:
-                change_event = extract_body(record['body'])
-                if change_event.pop('Staff', None) != None:
-                    record['body'] = json_str_body(change_event)
-                    logger.info("Redacted 'Staff' key from Change Event payload")
+        for record in event['Records']:
+            change_event = extract_body(record['body'])
+            if change_event.pop('Staff', None) is not None:
+                record['body'] = json_str_body(change_event)
+                logger.info("Redacted 'Staff' key from Change Event payload")
     return handler(event, context)
+
 
 @lambda_handler_decorator(trace_execution=True)
 def unhandled_exception_logging(handler, event, context: LambdaContext):

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -9,17 +9,6 @@ from common.utilities import extract_body, json_str_body
 
 logger = Logger(child=True)
 
-# @lambda_handler_decorator(trace_execution=True)
-# def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext):
-#     logger.info(f"Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
-#     if len(list(event.records)) > 0:
-#             for record in event.records:
-#                 change_event = extract_body(record.body)
-#                 if change_event.pop('Staff', None) != None:
-#                     record = json_str_body(change_event)
-#                     logger.info("Redacted 'Staff' key from Change Event payload")
-#     return handler(event, context)
-
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event, context: LambdaContext):
     logger.info(f"Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
@@ -33,25 +22,20 @@ def redact_staff_key_from_event(handler, event, context: LambdaContext):
 
 @lambda_handler_decorator(trace_execution=True)
 def unhandled_exception_logging(handler, event, context: LambdaContext):
-    # if isinstance(event, SQSEvent):
-    #     # raw_event = event.raw_event
-    #     raw_event = str(event)
-    # else:
-    #     raw_event = event
 
     try:
         response = handler(event, context)
         return response
     except ValidationException as err:
-        logger.exception(f"Validation Error - {err}", extra={"error": err, "event": raw_event})
+        logger.exception(f"Validation Error - {err}", extra={"error": err, "event": event})
         return
     except ClientError as err:
         error_code = err.response["Error"]["Code"]
         error_msg = err.response["Error"]["Message"]
-        logger.exception(f"Boto3 Client Error - '{error_code}': {error_msg}", extra={"error": err, "event": raw_event})
+        logger.exception(f"Boto3 Client Error - '{error_code}': {error_msg}", extra={"error": err, "event": event})
         raise err
     except BaseException as err:
-        logger.exception(f"Something went wrong - {err}", extra={"error": err, "event": raw_event})
+        logger.exception(f"Something went wrong - {err}", extra={"error": err, "event": event})
         raise err
 
 

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -10,7 +10,7 @@ logger = Logger(child=True)
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event, context: LambdaContext):
     logger.info("Checking if 'Staff' key needs removing from Change Event payload")
-    if 'records' in event and len(list(event.records)) > 0:
+    if 'Records' in event and len(list(event.records)) > 0:
             for record in event.records:
                 if record.pop('Staff', None) != None:
                     logger.info("Redacted 'Staff' key from Change Event payload")

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -10,7 +10,7 @@ logger = Logger(child=True)
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event, context: LambdaContext):
 
-    if len(list(event.records)) > 0:
+    if 'records' in event and len(list(event.records)) > 0:
             for record in event.records:
                 if record.pop('Staff', None) != None:
                     logger.info("Redacted 'Staff' key from Change Event payload")

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -1,17 +1,17 @@
 from aws_lambda_powertools.logging import Logger
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from aws_lambda_powertools.utilities.data_classes import SQSEvent
+from aws_lambda_powertools.utilities.data_classes import event_source, SQSEvent
 from botocore.exceptions import ClientError
 
 from common.errors import ValidationException
 
 logger = Logger(child=True)
 
+@event_source(data_class=SQSEvent)
 @lambda_handler_decorator(trace_execution=True)
-def redact_staff_key_from_event(handler, event, context: LambdaContext):
-    if SQSEvent.isinstance(event):
-        if len(list(event.records)) > 0:
+def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext):
+    if len(list(event.records)) > 0:
             for record in event.records:
                 if record.pop('Staff', None) != None:
                     logger.info("Redacted 'Staff' key from Change Event payload")

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -10,11 +10,11 @@ logger = Logger(child=True)
 
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext):
-    logger.info("Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
-    # if 'Records' in event and len(list(event['Records'])) > 0:
-    #         for record in event['Records']:
-    #             if record['body'].pop('Staff', None) != None:
-    #                 logger.info("Redacted 'Staff' key from Change Event payload")
+    logger.info(f"Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
+    if 'Records' in event and len(list(event['Records'])) > 0:
+            for record in event['Records']:
+                if record['body'].pop('Staff', None) != None:
+                    logger.info("Redacted 'Staff' key from Change Event payload")
     return handler(event, context)
 
 

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -33,11 +33,11 @@ def redact_staff_key_from_event(handler, event, context: LambdaContext):
 
 @lambda_handler_decorator(trace_execution=True)
 def unhandled_exception_logging(handler, event, context: LambdaContext):
-    if isinstance(event, SQSEvent):
-        # raw_event = event.raw_event
-        raw_event = str(event)
-    else:
-        raw_event = event
+    # if isinstance(event, SQSEvent):
+    #     # raw_event = event.raw_event
+    #     raw_event = str(event)
+    # else:
+    #     raw_event = event
 
     try:
         response = handler(event, context)

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -23,15 +23,15 @@ def unhandled_exception_logging(handler, event, context: LambdaContext):
         response = handler(event, context)
         return response
     except ValidationException as err:
-        logger.exception(f"Validation Error - {err}", extra={"error": err, "event": redact_event})
+        logger.exception(f"Validation Error - {err}", extra={"error": err, "event": event})
         return
     except ClientError as err:
         error_code = err.response["Error"]["Code"]
         error_msg = err.response["Error"]["Message"]
-        logger.exception(f"Boto3 Client Error - '{error_code}': {error_msg}", extra={"error": err, "event": redact_event})
+        logger.exception(f"Boto3 Client Error - '{error_code}': {error_msg}", extra={"error": err, "event": event})
         raise err
     except BaseException as err:
-        logger.exception(f"Something went wrong - {err}", extra={"error": err, "event": redact_event})
+        logger.exception(f"Something went wrong - {err}", extra={"error": err, "event": event})
         raise err
 
 

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -10,8 +10,8 @@ logger = Logger(child=True)
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event, context: LambdaContext):
     logger.info("Checking if 'Staff' key needs removing from Change Event payload")
-    if 'Records' in event and len(list(event.records)) > 0:
-            for record in event.records:
+    if 'Records' in event and len(list(event['Records'])) > 0:
+            for record in event['Records']:
                 if record.pop('Staff', None) != None:
                     logger.info("Redacted 'Staff' key from Change Event payload")
     return handler(event, context)

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -1,16 +1,15 @@
 from aws_lambda_powertools.logging import Logger
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
 from aws_lambda_powertools.utilities.typing import LambdaContext
-from aws_lambda_powertools.utilities.data_classes import event_source, SQSEvent
 from botocore.exceptions import ClientError
 
 from common.errors import ValidationException
 
 logger = Logger(child=True)
 
-@event_source(data_class=SQSEvent)
 @lambda_handler_decorator(trace_execution=True)
-def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext):
+def redact_staff_key_from_event(handler, event, context: LambdaContext):
+
     if len(list(event.records)) > 0:
             for record in event.records:
                 if record.pop('Staff', None) != None:

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -1,6 +1,7 @@
 from aws_lambda_powertools.logging import Logger
 from aws_lambda_powertools.middleware_factory import lambda_handler_decorator
 from aws_lambda_powertools.utilities.typing import LambdaContext
+from aws_lambda_powertools.utilities.data_classes import SQSEvent
 from botocore.exceptions import ClientError
 
 from common.errors import ValidationException
@@ -10,6 +11,12 @@ logger = Logger(child=True)
 
 @lambda_handler_decorator(trace_execution=True)
 def unhandled_exception_logging(handler, event, context: LambdaContext):
+    if SQSEvent.isinstance(event):
+         if len(list(event.records)) > 0:
+            for record in event.records:
+                if record.pop('Staff', None) != None:
+                    logger.info("Redacted 'Staff' key from Change Event payload")
+
     try:
         response = handler(event, context)
         return response

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -14,7 +14,7 @@ def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext
     logger.info(f"Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
     if len(list(event.records)) > 0:
             for record in event.records:
-                change_event = extract_body(record)
+                change_event = extract_body(record.body)
                 if change_event.pop('Staff', None) != None:
                     record = json_str_body(change_event)
                     logger.info("Redacted 'Staff' key from Change Event payload")

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -25,7 +25,8 @@ def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext
 def unhandled_exception_logging(handler, event, context: LambdaContext):
     if isinstance(event, SQSEvent):
         raw_event = event.raw_event
-    raw_event = event
+    else:
+        raw_event = event
 
     try:
         response = handler(event, context)

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -12,7 +12,7 @@ def redact_staff_key_from_event(handler, event, context: LambdaContext):
     logger.info("Checking if 'Staff' key needs removing from Change Event payload")
     if 'Records' in event and len(list(event['Records'])) > 0:
             for record in event['Records']:
-                if record.pop('Staff', None) != None:
+                if record['body'].pop('Staff', None) != None:
                     logger.info("Redacted 'Staff' key from Change Event payload")
     return handler(event, context)
 

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -9,17 +9,27 @@ from common.utilities import extract_body, json_str_body
 
 logger = Logger(child=True)
 
+# @lambda_handler_decorator(trace_execution=True)
+# def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext):
+#     logger.info(f"Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
+#     if len(list(event.records)) > 0:
+#             for record in event.records:
+#                 change_event = extract_body(record.body)
+#                 if change_event.pop('Staff', None) != None:
+#                     record = json_str_body(change_event)
+#                     logger.info("Redacted 'Staff' key from Change Event payload")
+#     return handler(event, context)
+
 @lambda_handler_decorator(trace_execution=True)
-def redact_staff_key_from_event(handler, event: SQSEvent, context: LambdaContext):
+def redact_staff_key_from_event(handler, event, context: LambdaContext):
     logger.info(f"Checking if 'Staff' key needs removing from Change Event payload {event}", extra={"event": event})
-    if len(list(event.records)) > 0:
-            for record in event.records:
-                change_event = extract_body(record.body)
+    if 'Records' in event and len(list(event['Records'])) > 0:
+            for record in event['Records']:
+                change_event = extract_body(record['body'])
                 if change_event.pop('Staff', None) != None:
-                    record = json_str_body(change_event)
+                    record['body'] = json_str_body(change_event)
                     logger.info("Redacted 'Staff' key from Change Event payload")
     return handler(event, context)
-
 
 @lambda_handler_decorator(trace_execution=True)
 def unhandled_exception_logging(handler, event, context: LambdaContext):

--- a/application/common/middlewares.py
+++ b/application/common/middlewares.py
@@ -9,6 +9,7 @@ logger = Logger(child=True)
 
 @lambda_handler_decorator(trace_execution=True)
 def redact_staff_key_from_event(handler, event, context: LambdaContext):
+    logger.info("Checking if 'Staff' key needs removing from Change Event payload")
     if 'records' in event and len(list(event.records)) > 0:
             for record in event.records:
                 if record.pop('Staff', None) != None:

--- a/application/common/tests/STANDARD_EVENT_WITH_STAFF.json
+++ b/application/common/tests/STANDARD_EVENT_WITH_STAFF.json
@@ -1,0 +1,200 @@
+{
+  "ODSCode": "TES73",
+  "OrganisationName": "Fake Pharmacy",
+  "OrganisationTypeId": "PHA",
+  "OrganisationType": "Pharmacy",
+  "OrganisationSubType": "Community",
+  "OrganisationStatus": "Visible",
+  "Address1": "Flat 619",
+  "Address2": "62 Fake Street",
+  "Address3": "Hazel Grove",
+  "City": "Bath",
+  "County": "Somerset",
+  "Postcode": "TE5 7ER",
+  "ParentOrganisation": {
+    "ODSCode": "TES",
+    "OrganisationName": "Fake Pharmacy Corperation"
+  },
+  "Contacts": [
+    {
+      "ContactType": "Primary",
+      "ContactAvailabilityType": "Office hours",
+      "ContactMethodType": "Website",
+      "ContactValue": "http://www.FakePharmacy.co.uk/"
+    },
+    {
+      "ContactType": "Primary",
+      "ContactAvailabilityType": "Office hours",
+      "ContactMethodType": "Telephone",
+      "ContactValue": "01234 567890"
+    }
+  ],
+  "Staff": [
+    {
+      "Title": "Mr",
+      "GivenName": "Dave",
+      "FamilyName": "Davies",
+      "Role": "Stub",
+      "Qualification": "Unit"
+    },
+    {
+      "Title": "Mr",
+      "GivenName": "Dummy",
+      "FamilyName": "Stubb",
+      "Role": "Tester",
+      "Qualification": ""
+    }
+  ],
+  "OpeningTimes": [
+    {
+      "Weekday": "Monday",
+      "OpeningTime": "09:00",
+      "ClosingTime": "13:00",
+      "OffsetOpeningTime": 540,
+      "OffsetClosingTime": 780,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "Monday",
+      "OpeningTime": "14:00",
+      "ClosingTime": "17:30",
+      "OffsetOpeningTime": 840,
+      "OffsetClosingTime": 1050,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "Tuesday",
+      "OpeningTime": "09:00",
+      "ClosingTime": "13:00",
+      "OffsetOpeningTime": 540,
+      "OffsetClosingTime": 780,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "Tuesday",
+      "OpeningTime": "14:00",
+      "ClosingTime": "17:30",
+      "OffsetOpeningTime": 840,
+      "OffsetClosingTime": 1050,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "Wednesday",
+      "OpeningTime": "09:00",
+      "ClosingTime": "13:00",
+      "OffsetOpeningTime": 540,
+      "OffsetClosingTime": 780,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "Wednesday",
+      "OpeningTime": "14:00",
+      "ClosingTime": "17:30",
+      "OffsetOpeningTime": 840,
+      "OffsetClosingTime": 1050,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "Thursday",
+      "OpeningTime": "09:00",
+      "ClosingTime": "13:00",
+      "OffsetOpeningTime": 540,
+      "OffsetClosingTime": 780,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "Thursday",
+      "OpeningTime": "14:00",
+      "ClosingTime": "17:30",
+      "OffsetOpeningTime": 840,
+      "OffsetClosingTime": 1050,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "Friday",
+      "OpeningTime": "09:00",
+      "ClosingTime": "13:00",
+      "OffsetOpeningTime": 540,
+      "OffsetClosingTime": 780,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "Friday",
+      "OpeningTime": "14:00",
+      "ClosingTime": "17:30",
+      "OffsetOpeningTime": 840,
+      "OffsetClosingTime": 1050,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "Saturday",
+      "OpeningTime": "09:00",
+      "ClosingTime": "13:00",
+      "OffsetOpeningTime": 540,
+      "OffsetClosingTime": 720,
+      "OpeningTimeType": "General",
+      "AdditionalOpeningDate": "",
+      "IsOpen": true
+    },
+    {
+      "Weekday": "",
+      "OpeningTime": "",
+      "ClosingTime": "",
+      "OffsetOpeningTime": 0,
+      "OffsetClosingTime": 0,
+      "OpeningTimeType": "Additional",
+      "AdditionalOpeningDate": "Dec 24 2021",
+      "IsOpen": false
+    },
+    {
+      "Weekday": "",
+      "OpeningTime": "",
+      "ClosingTime": "",
+      "OffsetOpeningTime": 0,
+      "OffsetClosingTime": 0,
+      "OpeningTimeType": "Additional",
+      "AdditionalOpeningDate": "Dec 25 2021",
+      "IsOpen": false
+    },
+    {
+      "Weekday": "",
+      "OpeningTime": "",
+      "ClosingTime": "",
+      "OffsetOpeningTime": 0,
+      "OffsetClosingTime": 0,
+      "OpeningTimeType": "Additional",
+      "AdditionalOpeningDate": "Dec 26 2021",
+      "IsOpen": false
+    },
+    {
+      "Weekday": "",
+      "OpeningTime": "",
+      "ClosingTime": "",
+      "OffsetOpeningTime": 0,
+      "OffsetClosingTime": 0,
+      "OpeningTimeType": "Additional",
+      "AdditionalOpeningDate": "Dec 27 2021",
+      "IsOpen": false
+    }
+  ]
+}

--- a/application/common/tests/conftest.py
+++ b/application/common/tests/conftest.py
@@ -15,6 +15,9 @@ STD_EVENT_PATH = path.join(Path(__file__).parent.resolve(), "STANDARD_EVENT.json
 with open(STD_EVENT_PATH, "r", encoding="utf8") as file:
     PHARMACY_STANDARD_EVENT = json.load(file)
 
+STD_EVENT_STAFF_PATH = path.join(Path(__file__).parent.resolve(), "STANDARD_EVENT_WITH_STAFF.json")
+with open(STD_EVENT_STAFF_PATH, "r", encoding="utf8") as file:
+    PHARMACY_STANDARD_EVENT_STAFF = json.load(file)
 
 def get_std_event(**kwargs) -> dict:
     event = PHARMACY_STANDARD_EVENT.copy()

--- a/application/common/tests/conftest.py
+++ b/application/common/tests/conftest.py
@@ -19,6 +19,7 @@ STD_EVENT_STAFF_PATH = path.join(Path(__file__).parent.resolve(), "STANDARD_EVEN
 with open(STD_EVENT_STAFF_PATH, "r", encoding="utf8") as file:
     PHARMACY_STANDARD_EVENT_STAFF = json.load(file)
 
+
 def get_std_event(**kwargs) -> dict:
     event = PHARMACY_STANDARD_EVENT.copy()
     for name, value in kwargs.items():

--- a/application/common/tests/test_middlewares.py
+++ b/application/common/tests/test_middlewares.py
@@ -40,7 +40,7 @@ def test_redact_staff_key_from_event(caplog):
     assert "Staff" in extract_body(event["Records"][0]["body"])
     # Act
     result = dummy_handler(event, None)
-    assert "Redacted 'Staff' key from Change Event payload" in caplog.text
+    assert "Redacted 'Staff' key from Change Event payload body" in caplog.text
     assert "Staff" not in extract_body(result["Records"][0]["body"])
 
 

--- a/application/common/tests/test_middlewares.py
+++ b/application/common/tests/test_middlewares.py
@@ -25,6 +25,7 @@ def test_redact_staff_key_from_event_with_no_staff_key(caplog):
     assert "Staff" not in extract_body(event["Records"][0]["body"])
     # Act
     result = dummy_handler(event, None)
+    assert "Checking if 'Staff' key needs removing from Change Event payload" in caplog.text
     assert "Redacted 'Staff' key from Change Event payload" not in caplog.text
     assert "Staff" not in extract_body(result["Records"][0]["body"])
 
@@ -40,8 +41,24 @@ def test_redact_staff_key_from_event(caplog):
     assert "Staff" in extract_body(event["Records"][0]["body"])
     # Act
     result = dummy_handler(event, None)
+    assert "Checking if 'Staff' key needs removing from Change Event payload" in caplog.text
     assert "Redacted 'Staff' key from Change Event payload" in caplog.text
     assert "Staff" not in extract_body(result["Records"][0]["body"])
+
+
+def test_redact_staff_key_from_event_no_records(caplog):
+    @redact_staff_key_from_event()
+    def dummy_handler(event, context):
+        return event
+
+    # Arrange
+    event = SQS_EVENT.copy()
+    event["Records"] = []
+    # Act
+    result = dummy_handler(event, None)
+    assert "Checking if 'Staff' key needs removing from Change Event payload" in caplog.text
+    assert "Redacted 'Staff' key from Change Event payload" not in caplog.text
+    assert len(result["Records"]) == 0
 
 
 def test_unhandled_exception_logging(caplog):

--- a/application/common/tests/test_middlewares.py
+++ b/application/common/tests/test_middlewares.py
@@ -22,10 +22,12 @@ def test_redact_staff_key_from_event_with_no_staff_key(caplog):
     # Arrange
     event = SQS_EVENT.copy()
     event["Records"][0]["body"] = dumps(PHARMACY_STANDARD_EVENT.copy())
+    assert "Staff" not in extract_body(event["Records"][0]["body"])
     # Act
     result = dummy_handler(event, None)
     assert "Redacted 'Staff' key from Change Event payload" not in caplog.text
-    assert "Staff" not in extract_body(event["Records"][0]["body"])
+    assert "Staff" not in extract_body(result["Records"][0]["body"])
+
 
 def test_redact_staff_key_from_event(caplog):
     @redact_staff_key_from_event()
@@ -35,10 +37,12 @@ def test_redact_staff_key_from_event(caplog):
     # Arrange
     event = SQS_EVENT.copy()
     event['Records'][0]['body'] = dumps(PHARMACY_STANDARD_EVENT_STAFF.copy())
+    assert "Staff" in extract_body(event["Records"][0]["body"])
     # Act
     result = dummy_handler(event, None)
     assert "Redacted 'Staff' key from Change Event payload" in caplog.text
-    assert "Staff" not in extract_body(event["Records"][0]["body"])
+    assert "Staff" not in extract_body(result["Records"][0]["body"])
+
 
 def test_unhandled_exception_logging(caplog):
     @unhandled_exception_logging

--- a/application/common/tests/test_middlewares.py
+++ b/application/common/tests/test_middlewares.py
@@ -4,7 +4,18 @@ from aws_lambda_powertools.utilities.data_classes import SQSEvent
 from botocore.exceptions import ClientError
 from pytest import raises
 
-from ..middlewares import unhandled_exception_logging, unhandled_exception_logging_hidden_event
+from ..middlewares import redact_staff_key_from_event, unhandled_exception_logging, unhandled_exception_logging_hidden_event
+
+
+def test_redact_staff_key_from_event():
+    @redact_staff_key_from_event()
+    def dummy_handler(event, context):
+        return event
+
+    # Arrange
+    event = SQS_EVENT.copy()
+    # Act
+    dummy_handler(event, None)
 
 
 def test_unhandled_exception_logging(caplog):
@@ -33,7 +44,8 @@ def test_unhandled_exception_logging_no_error():
         pass
 
     # Arrange
-    event = SQSEvent(None)
+    event = SQS_EVENT.copy()
+
     # Act
     dummy_handler(event, None)
 
@@ -59,3 +71,67 @@ def test_unhandled_exception_logging_hidden_event_no_error():
     event = SQSEvent(None)
     # Act
     dummy_handler(event, None)
+
+SQS_EVENT_BODY = '''{"description": "Default valid schema payload","SearchKey": "X","ODSCode": "XX123",
+    "OrganisationName": "Generic Pharmacy","OrganisationTypeId": "PHA","OrganisationType": "Pharmacy",
+    "OrganisationSubType": "Community","OrganisationStatus": "Visible",
+    "Address1": "22 STUB STREET","Address2": null,"Address3": null,"City": "TESTON","County": null,
+    "Latitude": 53.3623793029785,"Longitude": -2.15734055519104,"Postcode": "ST1 0UB",
+    "ParentOrganisation": {"ODSCode": "XOP", "OrganisationName": "TESTON Stub services"},
+    "OpeningTimes": [
+        {"Weekday": "Monday", "OpeningTime": "07:30","ClosingTime": "23:30", "OffsetOpeningTime": 540,
+        "OffsetClosingTime": 780, "OpeningTimeType": "General", "AdditionalOpeningDate": "", "IsOpen": true},
+        {"Weekday": "Tuesday","OpeningTime": "07:30","ClosingTime": "23:30","OffsetOpeningTime": 540,
+        "OffsetClosingTime": 780,"OpeningTimeType": "General","AdditionalOpeningDate": "","IsOpen": true},
+        {"Weekday": "wednesday","OpeningTime": "07:30","ClosingTime": "23:30","OffsetOpeningTime": 540,
+        "OffsetClosingTime": 780,"OpeningTimeType": "General","AdditionalOpeningDate": "","IsOpen": true},
+        {"Weekday": "Thursday","OpeningTime": "07:30","ClosingTime": "23:30","OffsetOpeningTime": 540,
+        "OffsetClosingTime": 780,"OpeningTimeType": "General","AdditionalOpeningDate": "","IsOpen": true},
+        {"Weekday": "Friday","OpeningTime": "07:30","ClosingTime": "23:30","OffsetOpeningTime": 540,
+        "OffsetClosingTime": 780,"OpeningTimeType": "General","AdditionalOpeningDate": "","IsOpen": true},
+        {"Weekday": "Saturday","OpeningTime": "07:32","ClosingTime": "23:00","OffsetOpeningTime": 540,
+        "OffsetClosingTime": 780,"OpeningTimeType": "General","AdditionalOpeningDate": "","IsOpen": true},
+        {"Weekday": "Sunday","OpeningTime": "10:00","ClosingTime": "17:00","OffsetOpeningTime": 540,
+        "OffsetClosingTime": 780,"OpeningTimeType": "General","AdditionalOpeningDate": "","IsOpen": true},
+        {"Weekday": "", "OpeningTime": "10:00", "ClosingTime": "17:00", "OffsetOpeningTime": 0, "OffsetClosingTime": 0,
+        "OpeningTimeType": "Additional", "AdditionalOpeningDate": "Dec 26 2022", "IsOpen": true}
+    ],
+    "Contacts": [
+        {"ContactType": "Primary", "ContactAvailabilityType": "Office hours", "ContactMethodType": "Website",
+        "ContactValue": "http://www.test.co.uk/"},
+        {"ContactType": "Primary", "ContactAvailabilityType": "Office hours", "ContactMethodType": "Email",
+        "ContactValue": "pharmacy.test@test.fake"},
+        {"ContactType": "Primary", "ContactAvailabilityType": "Office hours", "ContactMethodType": "Telephone",
+        "ContactValue": "0123 456 7891 2345 678 9"}
+    ],
+    "Staff": [
+        {"Title": "Mr", "GivenName": "Dave", "FamilyName": "Davies", "Role": "Stub", "Qualification": "Unit"},
+        {"Title": "Mr", "GivenName": "Dummy", "FamilyName": "Stubb", "Role": "Tester", "Qualification": ""}
+    ],
+    "Facilities": [{"Id": 1, "Value": "No"},{"Id": 2,"Value": "Yes"}],
+    "LastUpdatedDates": {"OpeningTimes": "2021-09-07T10:21:30+00:00", "Facilities": "2021-09-07T10:21:42+00:00",
+    "Services": "2021-09-07T10:21:36+00:00","ContactDetails": "2017-10-23T14:06:46+00:00"}}'''
+
+SQS_EVENT = {
+    "Records": [
+        {
+            "messageId": "059f36b4-87a3-44ab-83d2-661975830a7d",
+            "receiptHandle": "AQEBwJnKyrHigUMZj6rYigCgxlaS3SLy0a...",
+            "body": SQS_EVENT_BODY,
+            "attributes": {
+                "ApproximateReceiveCount": "1",
+                "SentTimestamp": "1642619743522",
+                "SenderId": "AIDAIENQZJOLO23YVJ4VO",
+                "ApproximateFirstReceiveTimestamp": "1545082649185",
+            },
+            "messageAttributes": {
+                "correlation-id": {"stringValue": "1", "dataType": "String"},
+                "sequence-number": {"stringValue": "1", "dataType": "Number"},
+            },
+            "md5OfBody": "e4e68fb7bd0e697a0ae8f1bb342846b3",
+            "eventSource": "aws:sqs",
+            "eventSourceARN": "arn:aws:sqs:us-east-2:123456789012:my-queue",
+            "awsRegion": "us-east-2",
+        }
+    ]
+}

--- a/application/common/tests/test_middlewares.py
+++ b/application/common/tests/test_middlewares.py
@@ -10,8 +10,8 @@ from ..middlewares import (
     unhandled_exception_logging,
     unhandled_exception_logging_hidden_event,
 )
+from ..tests.conftest import PHARMACY_STANDARD_EVENT, PHARMACY_STANDARD_EVENT_STAFF
 from ..utilities import extract_body
-from .conftest import PHARMACY_STANDARD_EVENT, PHARMACY_STANDARD_EVENT_STAFF
 
 
 def test_redact_staff_key_from_event_with_no_staff_key(caplog):

--- a/application/common/tests/test_middlewares.py
+++ b/application/common/tests/test_middlewares.py
@@ -40,7 +40,7 @@ def test_redact_staff_key_from_event(caplog):
     assert "Staff" in extract_body(event["Records"][0]["body"])
     # Act
     result = dummy_handler(event, None)
-    assert "Redacted 'Staff' key from Change Event payload body" in caplog.text
+    assert "Redacted 'Staff' key from Change Event payload" in caplog.text
     assert "Staff" not in extract_body(result["Records"][0]["body"])
 
 

--- a/application/common/tests/test_middlewares.py
+++ b/application/common/tests/test_middlewares.py
@@ -1,13 +1,18 @@
 import logging
+from json import dumps
 
 from aws_lambda_powertools.utilities.data_classes import SQSEvent
 from botocore.exceptions import ClientError
-from json import dumps
 from pytest import raises
 
+from ..middlewares import (
+    redact_staff_key_from_event,
+    unhandled_exception_logging,
+    unhandled_exception_logging_hidden_event,
+)
 from ..utilities import extract_body
-from ..middlewares import redact_staff_key_from_event, unhandled_exception_logging, unhandled_exception_logging_hidden_event
 from .conftest import PHARMACY_STANDARD_EVENT, PHARMACY_STANDARD_EVENT_STAFF
+
 
 def test_redact_staff_key_from_event_with_no_staff_key(caplog):
     @redact_staff_key_from_event()

--- a/application/common/tests/test_utilities.py
+++ b/application/common/tests/test_utilities.py
@@ -7,11 +7,11 @@ from pytest import mark, raises
 from ..utilities import (
     add_metric,
     extract_body,
-    json_str_body,
     get_sequence_number,
     get_sqs_msg_attribute,
     handle_sqs_msg_attributes,
     is_val_none_or_empty,
+    json_str_body,
     remove_given_keys_from_dict_by_msg_limit,
 )
 

--- a/application/common/tests/test_utilities.py
+++ b/application/common/tests/test_utilities.py
@@ -48,8 +48,9 @@ def test_json_str_body():
 
 def test_expected_json_str_exception():
     # Act & Assert
-    with raises(Exception):
+    with raises(Exception) as exception:
         json_str_body(body={"not a json dict"})
+        assert "Dict Change Event body cannot be converted to a JSON string" in str(exception.value)
 
 
 def test_get_sequence_number():

--- a/application/common/tests/test_utilities.py
+++ b/application/common/tests/test_utilities.py
@@ -7,6 +7,7 @@ from pytest import mark, raises
 from ..utilities import (
     add_metric,
     extract_body,
+    json_str_body,
     get_sequence_number,
     get_sqs_msg_attribute,
     handle_sqs_msg_attributes,
@@ -32,6 +33,23 @@ def test_extract_body_exception():
     # Act & Assert
     with raises(Exception):
         extract_body(expected_change_event)
+
+
+def test_json_str_body():
+    # Arrange
+    expected_json_str = '{"test": "test"}'
+    # Act
+    result = json_str_body({"test": "test"})
+    # Assert
+    assert (
+        result == expected_json_str
+    ), f"Change event body should be {expected_json_str} str but is {result}"
+
+
+def test_expected_json_str_exception():
+    # Act & Assert
+    with raises(Exception):
+        json_str_body(body={"not a json dict"})
 
 
 def test_get_sequence_number():

--- a/application/common/utilities.py
+++ b/application/common/utilities.py
@@ -43,7 +43,7 @@ def json_str_body(body: Dict[str, Any]) -> str:
         (str): A JSON string body
     """
     try:
-        return dumps(body).encode("utf-8")
+        return dumps(body)
     except ValueError as e:
         raise ValueError("Dict Change Event cannot be converted to a JSON string")
 

--- a/application/common/utilities.py
+++ b/application/common/utilities.py
@@ -34,6 +34,19 @@ def extract_body(body: str) -> Dict[str, Any]:
         raise ValueError("Change Event unable to be extracted") from e
     return body
 
+def json_str_body(body: Dict[str, Any]) -> str:
+    """Encode a Dict event body from the lambda function invocation event into a JSON string
+
+    Args:
+        body Dict[str, Any]: body as a dictionary
+    Returns:
+        (str): A JSON string body
+    """
+    try:
+        return dumps(body).encode("utf-8")
+    except ValueError as e:
+        raise ValueError("Dict Change Event cannot be converted to a JSON string")
+
 
 def get_sequence_number(record: SQSRecord) -> Union[int, None]:
     """Gets the sequence number from the SQS record sent by NHS UK

--- a/application/common/utilities.py
+++ b/application/common/utilities.py
@@ -34,6 +34,7 @@ def extract_body(body: str) -> Dict[str, Any]:
         raise ValueError("Change Event unable to be extracted") from e
     return body
 
+
 def json_str_body(body: Dict[str, Any]) -> str:
     """Encode a Dict event body from the lambda function invocation event into a JSON string
 
@@ -45,7 +46,7 @@ def json_str_body(body: Dict[str, Any]) -> str:
     try:
         return dumps(body)
     except ValueError as e:
-        raise ValueError("Dict Change Event cannot be converted to a JSON string")
+        raise ValueError("Dict Change Event cannot be converted to a JSON string") from e
 
 
 def get_sequence_number(record: SQSRecord) -> Union[int, None]:

--- a/application/common/utilities.py
+++ b/application/common/utilities.py
@@ -46,7 +46,7 @@ def json_str_body(body: Dict[str, Any]) -> str:
     try:
         return dumps(body)
     except ValueError as e:
-        raise ValueError("Dict Change Event cannot be converted to a JSON string") from e
+        raise ValueError("Dict Change Event body cannot be converted to a JSON string") from e
 
 
 def get_sequence_number(record: SQSRecord) -> Union[int, None]:

--- a/application/dos_db_handler/requirements.txt
+++ b/application/dos_db_handler/requirements.txt
@@ -1,2 +1,3 @@
+aws-embedded-metrics
 aws-lambda-powertools[tracer] ~= 2.1.0
 psycopg2-binary

--- a/application/event_replay/requirements.txt
+++ b/application/event_replay/requirements.txt
@@ -1,2 +1,3 @@
+aws-embedded-metrics
 aws-lambda-powertools[tracer] ~= 2.1.0
 simplejson

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -1,6 +1,7 @@
 from json import dumps
 from os import environ
 from time import gmtime, strftime, time_ns
+from typing import Any, Dict
 
 from aws_embedded_metrics import metric_scope
 from aws_lambda_powertools.logging import Logger

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -47,8 +47,8 @@ def lambda_handler(event: SQSEvent, context: LambdaContext, metrics) -> None:
 
     record = next(event.records)
     change_event = extract_body(record.body)
-    validate_change_event(change_event)
     redact_staff_key_from_change_event(change_event)
+    validate_change_event(change_event)
     ods_code = change_event.get("ODSCode")
     add_change_event_received_metric(ods_code=ods_code)
     logger.append_keys(ods_code=ods_code)

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -12,7 +12,7 @@ from boto3 import client
 
 from .change_event_validation import validate_change_event
 from common.dynamodb import add_change_event_to_dynamodb, get_latest_sequence_id_for_a_given_odscode_from_dynamodb
-from common.middlewares import unhandled_exception_logging
+from common.middlewares import unhandled_exception_logging, redact_staff_key_from_event
 from common.types import HoldingQueueChangeEventItem
 from common.utilities import extract_body, get_sequence_number, remove_given_keys_from_dict_by_msg_limit
 
@@ -20,7 +20,7 @@ logger = Logger()
 tracer = Tracer()
 sqs = client("sqs")
 
-
+@redact_staff_key_from_event()
 @unhandled_exception_logging()
 @tracer.capture_lambda_handler()
 @event_source(data_class=SQSEvent)

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -20,10 +20,10 @@ logger = Logger()
 tracer = Tracer()
 sqs = client("sqs")
 
-@event_source(data_class=SQSEvent)
 @redact_staff_key_from_event()
 @unhandled_exception_logging()
 @tracer.capture_lambda_handler()
+@event_source(data_class=SQSEvent)
 @logger.inject_lambda_context(
     clear_state=True,
     correlation_id_path='Records[0].messageAttributes."correlation-id".stringValue',

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -47,7 +47,6 @@ def lambda_handler(event: SQSEvent, context: LambdaContext, metrics) -> None:
 
     record = next(event.records)
     change_event = extract_body(record.body)
-    # change_event = redact_staff_key_from_change_event(change_event)
     validate_change_event(change_event)
     ods_code = change_event.get("ODSCode")
     add_change_event_received_metric(ods_code=ods_code)

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -92,18 +92,6 @@ def lambda_handler(event: SQSEvent, context: LambdaContext, metrics) -> None:
         MessageGroupId=ods_code,
     )
 
-
-def redact_staff_key_from_change_event(event: Dict[str, Any]) -> Dict[str, Any]:
-    """Remove the sensitive staff key from a change event
-    Args:
-        event (Dict[str, Any]): Lambda function invocation event
-    """
-
-    if event.pop('Staff', None) != None:
-        logger.info("Redacted 'Staff' key from Change Event payload")
-    return event
-
-
 @metric_scope
 def add_change_event_received_metric(ods_code: str, metrics) -> None:  # type: ignore
     """Adds a success metric to the custom metrics collection

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -1,7 +1,6 @@
 from json import dumps
 from os import environ
 from time import gmtime, strftime, time_ns
-from typing import Any, Dict
 
 from aws_embedded_metrics import metric_scope
 from aws_lambda_powertools.logging import Logger

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -47,7 +47,7 @@ def lambda_handler(event: SQSEvent, context: LambdaContext, metrics) -> None:
 
     record = next(event.records)
     change_event = extract_body(record.body)
-    redact_staff_key_from_change_event(change_event)
+    # change_event = redact_staff_key_from_change_event(change_event)
     validate_change_event(change_event)
     ods_code = change_event.get("ODSCode")
     add_change_event_received_metric(ods_code=ods_code)

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -20,10 +20,10 @@ logger = Logger()
 tracer = Tracer()
 sqs = client("sqs")
 
+@event_source(data_class=SQSEvent)
 @redact_staff_key_from_event()
 @unhandled_exception_logging()
 @tracer.capture_lambda_handler()
-@event_source(data_class=SQSEvent)
 @logger.inject_lambda_context(
     clear_state=True,
     correlation_id_path='Records[0].messageAttributes."correlation-id".stringValue',

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -12,13 +12,14 @@ from boto3 import client
 
 from .change_event_validation import validate_change_event
 from common.dynamodb import add_change_event_to_dynamodb, get_latest_sequence_id_for_a_given_odscode_from_dynamodb
-from common.middlewares import unhandled_exception_logging, redact_staff_key_from_event
+from common.middlewares import redact_staff_key_from_event, unhandled_exception_logging
 from common.types import HoldingQueueChangeEventItem
 from common.utilities import extract_body, get_sequence_number, remove_given_keys_from_dict_by_msg_limit
 
 logger = Logger()
 tracer = Tracer()
 sqs = client("sqs")
+
 
 @redact_staff_key_from_event()
 @unhandled_exception_logging()
@@ -90,6 +91,7 @@ def lambda_handler(event: SQSEvent, context: LambdaContext, metrics) -> None:
         MessageBody=dumps(holding_queue_change_event_item),
         MessageGroupId=ods_code,
     )
+
 
 @metric_scope
 def add_change_event_received_metric(ods_code: str, metrics) -> None:  # type: ignore

--- a/application/ingest_change_event/ingest_change_event.py
+++ b/application/ingest_change_event/ingest_change_event.py
@@ -92,10 +92,7 @@ def lambda_handler(event: SQSEvent, context: LambdaContext, metrics) -> None:
         MessageGroupId=ods_code,
     )
 
-@logger.inject_lambda_context(
-    clear_state=True,
-    correlation_id_path='Records[0].messageAttributes."correlation-id".stringValue',
-)
+
 def redact_staff_key_from_change_event(event: Dict[str, Any]) -> Dict[str, Any]:
     """Remove the sensitive staff key from a change event
     Args:
@@ -105,7 +102,6 @@ def redact_staff_key_from_change_event(event: Dict[str, Any]) -> Dict[str, Any]:
     if event.pop('Staff', None) != None:
         logger.info("Redacted 'Staff' key from Change Event payload")
     return event
-
 
 
 @metric_scope

--- a/application/ingest_change_event/tests/conftest.py
+++ b/application/ingest_change_event/tests/conftest.py
@@ -9,10 +9,12 @@ def log_capture():
     with LogCapture(names="lambda") as capture:
         yield capture
 
+
 @fixture
 def change_event():
     change_event = PHARMACY_STANDARD_EVENT.copy()
     yield change_event
+
 
 @fixture
 def change_event_staff():

--- a/application/ingest_change_event/tests/conftest.py
+++ b/application/ingest_change_event/tests/conftest.py
@@ -1,7 +1,7 @@
 from pytest import fixture
 from testfixtures import LogCapture
 
-from common.tests.conftest import PHARMACY_STANDARD_EVENT
+from common.tests.conftest import PHARMACY_STANDARD_EVENT, PHARMACY_STANDARD_EVENT_STAFF
 
 
 @fixture()
@@ -9,8 +9,12 @@ def log_capture():
     with LogCapture(names="lambda") as capture:
         yield capture
 
-
 @fixture
 def change_event():
     change_event = PHARMACY_STANDARD_EVENT.copy()
     yield change_event
+
+@fixture
+def change_event_staff():
+    change_event_staff = PHARMACY_STANDARD_EVENT_STAFF.copy()
+    yield change_event_staff

--- a/application/ingest_change_event/tests/test_ingest_change_event.py
+++ b/application/ingest_change_event/tests/test_ingest_change_event.py
@@ -123,6 +123,75 @@ def test_lambda_handler(
     del environ["HOLDING_QUEUE_URL"]
 
 
+@patch(f"{FILE_PATH}.sqs")
+@patch(f"{FILE_PATH}.HoldingQueueChangeEventItem")
+@patch(f"{FILE_PATH}.add_change_event_to_dynamodb")
+@patch(f"{FILE_PATH}.get_latest_sequence_id_for_a_given_odscode_from_dynamodb")
+@patch(f"{FILE_PATH}.remove_given_keys_from_dict_by_msg_limit")
+@patch(f"{FILE_PATH}.get_sequence_number")
+@patch(f"{FILE_PATH}.add_change_event_received_metric")
+@patch(f"{FILE_PATH}.validate_change_event")
+@patch(f"{FILE_PATH}.time_ns")
+def test_lambda_handler_with_sensitive_staff_key(
+    mock_time_ns: MagicMock,
+    mock_validate_change_event: MagicMock,
+    mock_add_change_event_received_metric: MagicMock,
+    mock_get_sequence_number: MagicMock,
+    mock_remove_given_keys_from_dict_by_msg_limit: MagicMock,
+    mock_get_latest_sequence_id_for_a_given_odscode_from_dynamodb: MagicMock,
+    mock_add_change_event_to_dynamodb: MagicMock,
+    mock_holding_queue_change_event_item: MagicMock,
+    mock_sqs: MagicMock,
+    change_event_staff: dict,
+    change_event: dict,
+    lambda_context: LambdaContext,
+):
+    # Arrange
+    event = SQS_EVENT.copy()
+    event["Records"][0]["body"] = dumps(change_event_staff)
+    environ["ENV"] = "test"
+    environ["HOLDING_QUEUE_URL"] = queue_url = "https://sqs.eu-west-1.amazonaws.com/000000000000/holding-queue"
+    sqs_timestamp = 1642619743522
+    mock_time_ns.return_value = 123456789
+    mock_get_latest_sequence_id_for_a_given_odscode_from_dynamodb.return_value = 1
+    mock_get_sequence_number.return_value = sequence_number = 2
+    mock_add_change_event_to_dynamodb.return_value = dynamodb_record = "1234567890"
+    mock_holding_queue_change_event_item.return_value = holding_queue_change_event_item = HoldingQueueChangeEventItem(
+        change_event=None,
+        dynamo_record_id=None,
+        correlation_id=None,
+        sequence_number=None,
+        message_received=None,  # type: ignore
+    )
+    # Act
+    response = lambda_handler(event, lambda_context)
+    # Assert
+    assert response is None
+    mock_time_ns.assert_called_once()
+    mock_validate_change_event.assert_called_once_with(change_event)
+    mock_add_change_event_received_metric.assert_called_once_with(ods_code=change_event["ODSCode"])
+    mock_remove_given_keys_from_dict_by_msg_limit.assert_called_once_with(
+        change_event, ["Facilities", "Metrics"], 10000
+    )
+    mock_get_latest_sequence_id_for_a_given_odscode_from_dynamodb.assert_called_once_with(change_event["ODSCode"])
+    mock_add_change_event_to_dynamodb.assert_called_once_with(change_event, sequence_number, sqs_timestamp)
+    mock_holding_queue_change_event_item.assert_called_once_with(
+        change_event=change_event,
+        sequence_number=sequence_number,
+        message_received=sqs_timestamp,
+        dynamo_record_id=dynamodb_record,
+        correlation_id="1",
+    )
+    mock_sqs.send_message.assert_called_once_with(
+        QueueUrl=queue_url,
+        MessageBody=dumps(holding_queue_change_event_item),
+        MessageGroupId=change_event["ODSCode"],
+    )
+    # Cleanup
+    del environ["ENV"]
+    del environ["HOLDING_QUEUE_URL"]
+
+
 @patch.object(Logger, "error")
 @patch(f"{FILE_PATH}.sqs")
 @patch(f"{FILE_PATH}.HoldingQueueChangeEventItem")

--- a/application/slack_messenger/requirements.txt
+++ b/application/slack_messenger/requirements.txt
@@ -1,2 +1,3 @@
+aws-embedded-metrics
 aws-lambda-powertools[tracer] ~= 2.1.0
 requests


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DI-47>**

## Description of Changes

Redacts the 'Staff' key from the Change Event after it has been recieved but before it is log or save to dynamoDB. This is done by defining a new decorator function, which is applied to lambda handler for the ingest change event and the change event dlq handler.

## Type of change

- New feature (non-breaking change which adds functionality)

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester