### PR TITLE
DSUEC-79 Alert when Alarms revert to OK state

### DIFF
--- a/infrastructure/stacks/blue-green-link/cloudwatch-alarms-lambda-error-rate.tf
+++ b/infrastructure/stacks/blue-green-link/cloudwatch-alarms-lambda-error-rate.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "change_event_dlq_handler_error_rate_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Change Event DLQ Handler error rate has exceeded 10%"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Change Event DLQ Handler Error Rate"
@@ -6,6 +7,8 @@ resource "aws_cloudwatch_metric_alarm" "change_event_dlq_handler_error_rate_aler
   evaluation_periods        = "2"
   threshold                 = "10"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 
   metric_query {
     id          = "expression"
@@ -44,6 +47,7 @@ resource "aws_cloudwatch_metric_alarm" "change_event_dlq_handler_error_rate_aler
 }
 
 resource "aws_cloudwatch_metric_alarm" "dos_db_update_dlq_handler_error_rate_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "DoS DB Update DLQ Handler error rate has exceeded 10%"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | DoS DB Update DLQ Handler Error Rate"
@@ -51,6 +55,8 @@ resource "aws_cloudwatch_metric_alarm" "dos_db_update_dlq_handler_error_rate_ale
   evaluation_periods        = "2"
   threshold                 = "10"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 
   metric_query {
     id          = "expression"
@@ -89,6 +95,7 @@ resource "aws_cloudwatch_metric_alarm" "dos_db_update_dlq_handler_error_rate_ale
 }
 
 resource "aws_cloudwatch_metric_alarm" "event_replay_error_rate_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Event Replay error rate has exceeded 10%"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Event Replay Error Rate"
@@ -96,6 +103,8 @@ resource "aws_cloudwatch_metric_alarm" "event_replay_error_rate_alert" {
   evaluation_periods        = "2"
   threshold                 = "10"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 
   metric_query {
     id          = "expression"
@@ -134,6 +143,7 @@ resource "aws_cloudwatch_metric_alarm" "event_replay_error_rate_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "ingest_change_event_error_rate_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Ingest Change Event error rate has exceeded 10%"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Ingest Change Event Error Rate"
@@ -141,6 +151,8 @@ resource "aws_cloudwatch_metric_alarm" "ingest_change_event_error_rate_alert" {
   evaluation_periods        = "2"
   threshold                 = "10"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 
   metric_query {
     id          = "expression"
@@ -179,6 +191,7 @@ resource "aws_cloudwatch_metric_alarm" "ingest_change_event_error_rate_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "orchestrator_error_rate_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Orchestrator error rate has exceeded 10%"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Orchestrator Error Rate"
@@ -186,6 +199,8 @@ resource "aws_cloudwatch_metric_alarm" "orchestrator_error_rate_alert" {
   evaluation_periods        = "2"
   threshold                 = "10"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 
   metric_query {
     id          = "expression"
@@ -224,6 +239,7 @@ resource "aws_cloudwatch_metric_alarm" "orchestrator_error_rate_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "send_email_error_rate_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Send Email error rate has exceeded 10%"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Send Email Error Rate"
@@ -231,6 +247,8 @@ resource "aws_cloudwatch_metric_alarm" "send_email_error_rate_alert" {
   evaluation_periods        = "2"
   threshold                 = "10"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 
   metric_query {
     id          = "expression"
@@ -269,6 +287,7 @@ resource "aws_cloudwatch_metric_alarm" "send_email_error_rate_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "service_matcher_error_rate_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Service Matcher error rate has exceeded 10%"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Service Matcher Error Rate"
@@ -276,6 +295,8 @@ resource "aws_cloudwatch_metric_alarm" "service_matcher_error_rate_alert" {
   evaluation_periods        = "2"
   threshold                 = "10"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 
   metric_query {
     id          = "expression"
@@ -314,6 +335,7 @@ resource "aws_cloudwatch_metric_alarm" "service_matcher_error_rate_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "service_sync_error_rate_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Service Sync error rate has exceeded 10%"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Service Sync Error Rate"
@@ -321,6 +343,8 @@ resource "aws_cloudwatch_metric_alarm" "service_sync_error_rate_alert" {
   evaluation_periods        = "2"
   threshold                 = "10"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 
   metric_query {
     id          = "expression"
@@ -359,6 +383,7 @@ resource "aws_cloudwatch_metric_alarm" "service_sync_error_rate_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "slack_messenger_error_rate_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Slack Messenger error rate has exceeded 10%"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Slack Messenger Error Rate"
@@ -366,6 +391,8 @@ resource "aws_cloudwatch_metric_alarm" "slack_messenger_error_rate_alert" {
   evaluation_periods        = "2"
   threshold                 = "10"
   insufficient_data_actions = []
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 
   metric_query {
     id          = "expression"

--- a/infrastructure/stacks/blue-green-link/cloudwatch-alarms.tf
+++ b/infrastructure/stacks/blue-green-link/cloudwatch-alarms.tf
@@ -33,6 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "service_matcher_invalid_opening_times_al
 }
 
 resource "aws_cloudwatch_metric_alarm" "holiding_sqs_dlq_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when the Holding Queue Message DLQ has recieved messages"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Holding Queue Message DLQ'd"
@@ -49,6 +50,7 @@ resource "aws_cloudwatch_metric_alarm" "holiding_sqs_dlq_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "update_request_dlq_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when the Update Request DLQ has recieved messages"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Update Requests DLQ'd"
@@ -65,6 +67,7 @@ resource "aws_cloudwatch_metric_alarm" "update_request_dlq_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "dos_db_db_connections_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert when the DoS DB has too many connections"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | High DB Connections"
@@ -78,9 +81,12 @@ resource "aws_cloudwatch_metric_alarm" "dos_db_db_connections_alert" {
   period                    = "60"
   statistic                 = "Maximum"
   threshold                 = "250"
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "dos_db_replica_db_connections_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert when the DoS DI Replica DB has too many connections"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | High DB Replica Connections"
@@ -94,9 +100,12 @@ resource "aws_cloudwatch_metric_alarm" "dos_db_replica_db_connections_alert" {
   period                    = "60"
   statistic                 = "Maximum"
   threshold                 = "250"
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "dos_db_cpu_utilisation_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert when the DoS DB has too high CPU Utilisation"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | High DB CPU Utilisation"
@@ -110,9 +119,12 @@ resource "aws_cloudwatch_metric_alarm" "dos_db_cpu_utilisation_alert" {
   period                    = "60"
   statistic                 = "Maximum"
   threshold                 = "70"
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "dos_db_replica_cpu_utilisation_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert when the DoS DI Replica DB has too high CPU Utilisation"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | High DB Replica CPU Utilisation"
@@ -126,10 +138,13 @@ resource "aws_cloudwatch_metric_alarm" "dos_db_replica_cpu_utilisation_alert" {
   period                    = "60"
   statistic                 = "Maximum"
   threshold                 = "70"
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 }
 
 
 resource "aws_cloudwatch_metric_alarm" "high_number_of_change_events_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert when the DI has recieved a high number of change events"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | High Number of Change Events received"
@@ -147,6 +162,7 @@ resource "aws_cloudwatch_metric_alarm" "high_number_of_change_events_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_number_of_update_requests_waiting_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when DI is waiting to process update requests in service sync"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Update Requests Waiting"
@@ -163,6 +179,7 @@ resource "aws_cloudwatch_metric_alarm" "high_number_of_update_requests_waiting_a
 }
 
 resource "aws_cloudwatch_metric_alarm" "health_check_failures_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert when the DoS DB or Replica is likely down or unaccessible and found by too many health check failures"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | High Health Check Failures"
@@ -176,6 +193,8 @@ resource "aws_cloudwatch_metric_alarm" "health_check_failures_alert" {
   period                    = "60" # 1 minute
   statistic                 = "Sum"
   threshold                 = "2"
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_number_of_failed_emails_alert" {
@@ -195,8 +214,9 @@ resource "aws_cloudwatch_metric_alarm" "high_number_of_failed_emails_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_number_emails_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
-  alarm_description         = "Alert for when DI is failing to send emails"
+  alarm_description         = "Alert for when DI is sending many emails"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | High Number of Emails Sent"
   comparison_operator       = "GreaterThanOrEqualToThreshold"
   dimensions                = { ENV = var.blue_green_environment }
@@ -210,6 +230,7 @@ resource "aws_cloudwatch_metric_alarm" "high_number_emails_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "average_message_latency_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when the Latency for when changes are taken to long to process and save"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Average Message Latency"
@@ -223,9 +244,12 @@ resource "aws_cloudwatch_metric_alarm" "average_message_latency_alert" {
   period                    = "300"
   statistic                 = "Average"
   threshold                 = "1800000" # 30 Minutes
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 }
 
 resource "aws_cloudwatch_metric_alarm" "maximum_message_latency_alert" {
+  count                     = var.profile == "dev" ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when DI is taking longer than expected to process update requests"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Maximum Message Latency"
@@ -239,4 +263,6 @@ resource "aws_cloudwatch_metric_alarm" "maximum_message_latency_alert" {
   period                    = "300"
   statistic                 = "Maximum"
   threshold                 = "7200000" # 2 Hours
+  treat_missing_data        = "notBreaching"
+  ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 }


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DSUEC-79>**

## Description of Changes

This code changes the alarms to mostly not be deployed in nonprod and also alert when an alarming alarm reverts back to ok state.