### PR TITLE
DI-70 Integration test for Staff field redaction

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[comple
 	echo RUN_ID=$$RUN_ID
 	make -s docker-run-tools \
 	IMAGE=$$(make _docker-get-reg)/tester:latest \
-	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json" \
+	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json --reruns 2 --reruns-delay 10" \
 	DIR=./test/integration \
 	ARGS=" \
 		-e SHARED_ENVIRONMENT=$(SHARED_ENVIRONMENT) \

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ integration-test: #End to end test DI project - mandatory: PROFILE, TAGS=[comple
 	echo RUN_ID=$$RUN_ID
 	make -s docker-run-tools \
 	IMAGE=$$(make _docker-get-reg)/tester:latest \
-	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json --reruns 2 --reruns-delay 10" \
+	CMD="pytest steps -k $(TAGS) -vvvv --gherkin-terminal-reporter -p no:sugar -n $(PARALLEL_TEST_COUNT) --cucumberjson=./testresults.json" \
 	DIR=./test/integration \
 	ARGS=" \
 		-e SHARED_ENVIRONMENT=$(SHARED_ENVIRONMENT) \

--- a/test/integration/features/F001_Valid_Change_Events.feature
+++ b/test/integration/features/F001_Valid_Change_Events.feature
@@ -164,7 +164,7 @@ Feature: F001. Ensure valid change events are converted and sent to DOS
     When the Changed Event is sent for processing with "valid" api key
     Then the DoS service has been updated with the specified date and time is captured by DoS
 
-@complete @pharmacy_cloudwatch_queries @kit
+@complete @pharmacy_cloudwatch_queries
   Scenario: F001SX21. No Staff field in CE doesn't cause errors
     Given a basic service is created
     And the change event "Postcode" is set to "CT1 1AA"

--- a/test/integration/features/F001_Valid_Change_Events.feature
+++ b/test/integration/features/F001_Valid_Change_Events.feature
@@ -164,6 +164,14 @@ Feature: F001. Ensure valid change events are converted and sent to DOS
     When the Changed Event is sent for processing with "valid" api key
     Then the DoS service has been updated with the specified date and time is captured by DoS
 
+@complete @pharmacy_cloudwatch_queries @kit
+  Scenario: F001SX21. No Staff field in CE doesn't cause errors
+    Given a basic service is created
+    And the change event "Postcode" is set to "CT1 1AA"
+    And the change event has no staff field
+    When the Changed Event is sent for processing with "valid" api key
+    Then the "Postcode" is updated within the DoS DB
+
   # @complete @broken @dentist_no_log_searches @dentist_smoke_test
   # Scenario: F001S004. A valid Dentist change event is processed into DOS
   #   Given a "dentist" Changed Event is aligned with DoS

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -32,7 +32,7 @@ Feature: F002. Invalid change event Exception handling
     Then the "ingest-change-event" lambda shows field "message" with message "Validation Error - Unexpected Org Type ID: 'DEN'"
     And the service history is not updated
 
-  @complete @dev @pharmacy_cloudwatch_queries @kit
+  @complete @dev @pharmacy_cloudwatch_queries
   Scenario: F002SXX5. A Changed Event where OrganisationSubType is NOT Community is reported and ignored
     Given a basic service is created
     And the change event "OrganisationSubType" is set to "com"

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -32,14 +32,15 @@ Feature: F002. Invalid change event Exception handling
     Then the "ingest-change-event" lambda shows field "message" with message "Validation Error - Unexpected Org Type ID: 'DEN'"
     And the service history is not updated
 
-  @complete @dev @pharmacy_cloudwatch_queries
+  @complete @dev @pharmacy_cloudwatch_queries @kit
   Scenario: F002SXX5. A Changed Event where OrganisationSubType is NOT Community is reported and ignored
     Given a basic service is created
     And the change event "OrganisationSubType" is set to "com"
     When the Changed Event is sent for processing with "valid" api key
-    Then the "ingest-change-event" lambda shows field "message" with message "Validation Error - Unexpected Org Sub Type ID: 'com'"
-    And logs show staff data has been redacted
+    Then logs show staff data has been redacted
     And error messages do not show Staff data
+    And the "ingest-change-event" lambda shows field "message" with message "Validation Error - Unexpected Org Sub Type ID: 'com'"
+
 
   @complete @dev @pharmacy_cloudwatch_queries
   Scenario: F002SXX6. A Changed Event with no postcode LAT Long Values is reported

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -36,6 +36,7 @@ Feature: F002. Invalid change event Exception handling
   Scenario: F002SXX5. A Changed Event where OrganisationSubType is NOT Community is reported and ignored
     Given a basic service is created
     And the change event "OrganisationSubType" is set to "com"
+    And the change event staff field is populated
     When the Changed Event is sent for processing with "valid" api key
     Then logs show staff data has been redacted
     And error messages do not show Staff data

--- a/test/integration/features/F002_Invalid_Change_Events.feature
+++ b/test/integration/features/F002_Invalid_Change_Events.feature
@@ -38,6 +38,8 @@ Feature: F002. Invalid change event Exception handling
     And the change event "OrganisationSubType" is set to "com"
     When the Changed Event is sent for processing with "valid" api key
     Then the "ingest-change-event" lambda shows field "message" with message "Validation Error - Unexpected Org Sub Type ID: 'com'"
+    And logs show staff data has been redacted
+    And error messages do not show Staff data
 
   @complete @dev @pharmacy_cloudwatch_queries
   Scenario: F002SXX6. A Changed Event with no postcode LAT Long Values is reported

--- a/test/integration/steps/test_steps.py
+++ b/test/integration/steps/test_steps.py
@@ -55,6 +55,7 @@ from .utilities.generator import (
     build_change_event_contacts,
     build_change_event_opening_times,
     commit_new_service_to_dos,
+    generate_staff,
     query_specified_opening_builder,
     query_standard_opening_builder,
     valid_change_event,
@@ -213,6 +214,11 @@ def ce_values_updated_in_context(field_name: str, values: str, context: Context)
     else:
         context.previous_value = context.change_event[field_name]
         context.change_event[field_name] = values
+    return context
+
+@given('the change event staff field is populated', target_fixture="context")
+def ce_staff_field_populated(context: Context):
+    context.change_event["Staff"] = generate_staff()
     return context
 
 

--- a/test/integration/steps/test_steps.py
+++ b/test/integration/steps/test_steps.py
@@ -222,6 +222,10 @@ def ce_staff_field_populated(context: Context):
     context.change_event["Staff"] = generate_staff()
     return context
 
+@given("the change event has no staff field", target_fixture="context")
+def ce_staff_field_removed(context: Context):
+    del context.change_event["Staff"]
+    return context
 
 @given(parse('the specified opening date is set to "{future_past}" date'), target_fixture="context")
 def future_set_specified_opening_date(future_past: str, context: Context):

--- a/test/integration/steps/test_steps.py
+++ b/test/integration/steps/test_steps.py
@@ -798,14 +798,14 @@ def show_service_sync_logs(context: Context):
     logs = loads(get_logs(query, "service-sync", context.start_time))["results"][0][0]["value"]
     assert "service_uid" and "service_name" not in logs, "ERROR: service uid and service name found in logs"
 
+
 @then("logs show staff data has been redacted", target_fixture="context")
 def ingest_staff_redaction(context: Context):
-    query = (
-        f'fields @message | sort @timestamp asc | filter correlation_id="{context.correlation_id}"'
-        '|filter message like "Redacted \'Staff\' key from Change Event payload"'
-    )
+    query = "fields @message | sort @timestamp asc" '|filter message like "key from Change Event payload"'
     logs = loads(get_logs(query, "ingest-change-event", context.start_time))
-    assert context.service_id in logs, "ERROR: Logs do not show redaction of staff field"
+    assert logs != [], "ERROR: Logs do not show redaction of staff field"
+    return context
+
 
 @then("error messages do not show Staff data", target_fixture="context")
 def error_contains_no_staff(context: Context):
@@ -815,3 +815,4 @@ def error_contains_no_staff(context: Context):
     )
     logs = loads(get_logs(query, "ingest-change-event", context.start_time))
     assert "Superintendent Pharmacist" not in logs, "ERROR: Logs output the staff field on error"
+    return context

--- a/test/integration/steps/test_steps.py
+++ b/test/integration/steps/test_steps.py
@@ -222,10 +222,12 @@ def ce_staff_field_populated(context: Context):
     context.change_event["Staff"] = generate_staff()
     return context
 
+
 @given("the change event has no staff field", target_fixture="context")
 def ce_staff_field_removed(context: Context):
     del context.change_event["Staff"]
     return context
+
 
 @given(parse('the specified opening date is set to "{future_past}" date'), target_fixture="context")
 def future_set_specified_opening_date(future_past: str, context: Context):

--- a/test/integration/steps/test_steps.py
+++ b/test/integration/steps/test_steps.py
@@ -216,7 +216,8 @@ def ce_values_updated_in_context(field_name: str, values: str, context: Context)
         context.change_event[field_name] = values
     return context
 
-@given('the change event staff field is populated', target_fixture="context")
+
+@given("the change event staff field is populated", target_fixture="context")
 def ce_staff_field_populated(context: Context):
     context.change_event["Staff"] = generate_staff()
     return context

--- a/test/integration/steps/utilities/generator.py
+++ b/test/integration/steps/utilities/generator.py
@@ -228,7 +228,7 @@ def build_change_event(context):
         "OrganisationType": "Pharmacy",
         "OrganisationTypeId": "PHA",
         "UniqueKey": generate_unique_key(),
-        "Staff": generate_staff(),
+        "Staff": [],
     }
     context.change_event = change_event
 

--- a/test/integration/steps/utilities/generator.py
+++ b/test/integration/steps/utilities/generator.py
@@ -228,9 +228,28 @@ def build_change_event(context):
         "OrganisationType": "Pharmacy",
         "OrganisationTypeId": "PHA",
         "UniqueKey": generate_unique_key(),
+        "Staff": generate_staff()
     }
     context.change_event = change_event
 
+def generate_staff():
+    staff_value = [
+        {
+            "Title": "Mr",
+            "GivenName": "Dave",
+            "FamilyName": "Davies",
+            "Role": "Superintendent Pharmacist",
+            "Qualification": "Pharmacist"
+        },
+        {
+            "Title": "Mr",
+            "GivenName": "Tim",
+            "FamilyName": "Timothy",
+            "Role": "Locum Pharmacist",
+            "Qualification": ""
+        }
+    ]
+    return staff_value
 
 def build_change_event_contacts(context) -> list:
     # This function will build the contacts for the CE

--- a/test/integration/steps/utilities/generator.py
+++ b/test/integration/steps/utilities/generator.py
@@ -228,9 +228,10 @@ def build_change_event(context):
         "OrganisationType": "Pharmacy",
         "OrganisationTypeId": "PHA",
         "UniqueKey": generate_unique_key(),
-        "Staff": generate_staff()
+        "Staff": generate_staff(),
     }
     context.change_event = change_event
+
 
 def generate_staff():
     staff_value = [
@@ -239,17 +240,12 @@ def generate_staff():
             "GivenName": "Dave",
             "FamilyName": "Davies",
             "Role": "Superintendent Pharmacist",
-            "Qualification": "Pharmacist"
+            "Qualification": "Pharmacist",
         },
-        {
-            "Title": "Mr",
-            "GivenName": "Tim",
-            "FamilyName": "Timothy",
-            "Role": "Locum Pharmacist",
-            "Qualification": ""
-        }
+        {"Title": "Mr", "GivenName": "Tim", "FamilyName": "Timothy", "Role": "Locum Pharmacist", "Qualification": ""},
     ]
     return staff_value
+
 
 def build_change_event_contacts(context) -> list:
     # This function will build the contacts for the CE


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DI-70>**

## Description of Changes

Two new steps in tests to verify staff field redaction. A new step was added instead of using generic functionality because the error message does not contain a correlation id.
Staff field added to the generator for the CE.

## Type of change

- Test

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester