### PR TITLE
DSUEC-100 Make Finding Palliative Care from Change Event More Robust

### DIFF
--- a/application/common/nhs.py
+++ b/application/common/nhs.py
@@ -88,7 +88,10 @@ class NHSEntity:
         Returns:
             bool: True if the service exists, False otherwise
         """
-        return any(item.get("ServiceCode") == service_code for item in self.entity_data.get("UecServices", []))
+        uec_services = (
+            self.entity_data.get("UecServices", []) if isinstance(self.entity_data.get("UecServices", []), list) else []
+        )
+        return any(item.get("ServiceCode") == service_code for item in uec_services)
 
     def _get_standard_opening_times(self) -> StandardOpeningTimes:
         """Filters the raw opening times data for standard weekly opening

--- a/application/common/tests/test_nhs.py
+++ b/application/common/tests/test_nhs.py
@@ -663,3 +663,27 @@ def test_match_nhs_entities_to_services():
     actual_result = match_nhs_entities_to_services(nhs_entities, dos_services)
 
     assert actual_result == expected_result
+
+
+@pytest.mark.parametrize(
+    "input_value, output_value",
+    [
+        ("", False),
+        (None, False),
+        ([], False),
+        ({}, False),
+        (
+            [
+                {
+                    "ServiceName": "Pharmacy palliative care medication stockholder",
+                    "ServiceDescription": None,
+                    "ServiceCode": "SRV0559",
+                }
+            ],
+            True,
+        ),
+    ],
+)
+def test_extract_uec_service(input_value, output_value):
+    entity = NHSEntity({"ODSCode": "V012345", "UecServices": input_value})
+    assert entity.extract_uec_service("SRV0559") == output_value


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DSUEC-100>**

## Description of Changes

This PR allows the UecServices key of the change event to be different to what is expected. Within reason!. To ensure DI continues to function while the initial state is set to null in Profile Manager.