### PR TITLE
Release/16.1 - Hotfix

### DIFF
--- a/build/automation/var/profile/live.mk
+++ b/build/automation/var/profile/live.mk
@@ -44,3 +44,10 @@ ACCEPTED_ORG_TYPES := PHA
 
 SERVICE_MATCHER_MAX_CONCURRENCY := 30
 SERVICE_SYNC_MAX_CONCURRENCY := 50
+
+# ==============================================================================
+# DoS DB Handler
+
+DOS_DEPLOYMENT_SECRETS := null
+DOS_DEPLOYMENT_SECRETS_PASSWORD_KEY := null
+DOS_DB_HANDLER_DB_READ_AND_WRITE_USER_NAME := null


### PR DESCRIPTION
# Release Branch Pull Request



## Description of Changes

Hotfix release to fix issue with the Serverless Framework deployment now requiring dos-db-handler lambda variables to be defined even when it isn't being deployed. See here for more details **<https://nhsd-jira.digital.nhs.uk/browse/DS-1183>**