### PR TITLE
DS-1198 Bump Up Load Test Event Load

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -386,7 +386,7 @@ load-test: # Create change events for load performance testing - mandatory: PROF
 	make -s docker-run-tools \
 		IMAGE=$$(make _docker-get-reg)/tester \
 		CMD="python -m locust -f load_test_locustfile.py --headless \
-			--users 50 --spawn-rate 2 --run-time 30m --stop-timeout 5	 --exit-code-on-error 0 \
+			--users 50 --spawn-rate 5 --exit-code-on-error 0 \
 			-H $(HTTPS_DOS_INTEGRATION_URL) \
 			" $(PERFORMANCE_TEST_DIR_AND_ARGS)
 

--- a/test/performance/load_test_locustfile.py
+++ b/test/performance/load_test_locustfile.py
@@ -11,7 +11,7 @@ class AllChangesChangeEvent(FastHttpUser):
     trace_id: str | None = None
     headers: dict[str, str] | None = None
     payload: dict[str, Any] | None = None
-    wait_time = constant_pacing(30)
+    wait_time = constant_pacing(10)
 
     def on_start(self) -> None:
         """Get the api key before starting the test."""
@@ -30,7 +30,7 @@ class OdscodeDoesNotExistInDoS(FastHttpUser):
     trace_id: str | None = None
     headers: dict[str, str] | None = None
     payload: dict[str, Any] | None = None
-    wait_time = constant_pacing(30)
+    wait_time = constant_pacing(10)
 
     def on_start(self) -> None:
         """Get the api key before starting the test."""


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1198>**

## Description of Changes

This PR bumps up the load test load to be closer to NHS UK's max load. This sets the load test to 5 requests per second similar to NHS UK's traffic.