### PR TITLE
DS-1183 Fix live db-dos-handler variable not being defined (Hotfix 16.1)

### DIFF
--- a/build/automation/var/profile/live.mk
+++ b/build/automation/var/profile/live.mk
@@ -44,3 +44,10 @@ ACCEPTED_ORG_TYPES := PHA
 
 SERVICE_MATCHER_MAX_CONCURRENCY := 30
 SERVICE_SYNC_MAX_CONCURRENCY := 50
+
+# ==============================================================================
+# DoS DB Handler
+
+DOS_DEPLOYMENT_SECRETS := null
+DOS_DEPLOYMENT_SECRETS_PASSWORD_KEY := null
+DOS_DB_HANDLER_DB_READ_AND_WRITE_USER_NAME := null


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1183>**

## Description of Changes

Hotfix release to fix issue with the Serverless Framework deployment now requiring dos-db-handler lambda variables to be defined even when it isn't being deployed. See here for more details https://nhsd-jira.digital.nhs.uk/browse/DS-1183

## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester