### PR TITLE
DS-1332 Add Cloudwatch Dashboard Variables

### DIFF
--- a/infrastructure/stacks/blue-green-link/cloudwatch-dashboards.tf
+++ b/infrastructure/stacks/blue-green-link/cloudwatch-dashboards.tf
@@ -2,6 +2,27 @@ resource "aws_cloudwatch_dashboard" "cloudwatch_monitoring_dashboard" {
   dashboard_name = var.cloudwatch_monitoring_dashboard_name
   dashboard_body = jsonencode(
     {
+      "variables" : [
+        {
+          "type" : "pattern",
+          "pattern" : "((?<=\")|(?<=-))${var.blue_green_environment}",
+          "inputType" : "select",
+          "id" : "CloudWatchVersionVariable",
+          "label" : "BlueGreenVersion",
+          "defaultValue" : var.blue_green_environment,
+          "visible" : true,
+          "values" : [
+            {
+              "value" : var.blue_green_environment,
+              "label" : var.blue_green_environment
+            },
+            {
+              "value" : var.previous_blue_green_environment,
+              "label" : var.previous_blue_green_environment
+            }
+          ]
+        }
+      ],
       "widgets" : [
         {
           "type" : "text",


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1332>**

## Description of Changes

This PR adds CloudWatch Dashboard variables to allow dashboard version switching between the current and rollback versions. 