### PR TITLE
DS-1372 Reduce CloudWatch Alarm Thresholds

### DIFF
--- a/infrastructure/stacks/blue-green-link/cloudwatch-alarms.tf
+++ b/infrastructure/stacks/blue-green-link/cloudwatch-alarms.tf
@@ -223,7 +223,7 @@ resource "aws_cloudwatch_metric_alarm" "average_message_latency_alert" {
   namespace                 = "UEC-DOS-INT"
   period                    = "300"
   statistic                 = "Average"
-  threshold                 = "1800000" # 30 Minutes
+  threshold                 = "120000" # 2 Minutes
   treat_missing_data        = "notBreaching"
   ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 }
@@ -242,7 +242,7 @@ resource "aws_cloudwatch_metric_alarm" "maximum_message_latency_alert" {
   namespace                 = "UEC-DOS-INT"
   period                    = "300"
   statistic                 = "Maximum"
-  threshold                 = "7200000" # 2 Hours
+  threshold                 = "120000" # 2 Minutes
   treat_missing_data        = "notBreaching"
   ok_actions                = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
 }


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1372>**

## Description of Changes

This PR reduces the CloudWatch Alarm thresholds to match the SLA due to DI's now improved performance.