### PR TITLE
DS-1435 Increase Pipeline Build Timeouts

### DIFF
--- a/infrastructure/stacks/development-and-deployment-tools/pipeline_stages.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/pipeline_stages.tf
@@ -50,7 +50,7 @@ resource "aws_codebuild_project" "di_unit_tests_stage" {
 resource "aws_codebuild_project" "di_build_image_stage" {
   name           = "${var.project_id}-${var.environment}-build-image-stage"
   description    = "Builds docker container image"
-  build_timeout  = "5"
+  build_timeout  = "15"
   queued_timeout = "5"
   service_role   = data.aws_iam_role.pipeline_role.arn
 


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1435>**

## Description of Changes

This PR is to increase CodeBuild timeouts to ensure the pipelines don't timeout in the build stage.