### PR TITLE
DS-156 Fix Blank Opening Times in Production Smoke Test

### DIFF
--- a/test/smoke/functions/change_event.py
+++ b/test/smoke/functions/change_event.py
@@ -26,7 +26,6 @@ class ChangeEvent:
         base_change_event = self._set_contact_details(base_change_event, "Telephone", self.phone)
         return self._set_opening_times(base_change_event)
 
-
     def _load_base_change_event(self) -> dict:
         """Load the base change event from the JSON file.
 

--- a/test/smoke/functions/service.py
+++ b/test/smoke/functions/service.py
@@ -6,6 +6,7 @@ from pytz import UTC
 
 from .aws import invoke_dos_db_handler_lambda
 from .change_event import ChangeEvent
+from .smoke_test_context import SmokeTestContext
 from .types import Demographics
 from .utilities import seconds_since_midnight
 
@@ -208,11 +209,12 @@ def check_demographic_field_updated(field: str, service_history_key: str, expect
     assert_field_updated_in_history()
 
 
-def check_standard_opening_times_updated(expected_value: list[dict]) -> None:
+def check_standard_opening_times_updated(expected_value: list[dict], smoke_test_context: SmokeTestContext) -> None:
     """Check that the standard opening times were updated in the services table and in service history.
 
     Args:
         expected_value (list[dict]): The expected value of the standard opening times
+        smoke_test_context (SmokeTestContext): The smoke test context
     """
 
     def assert_field_updated() -> None:
@@ -254,9 +256,10 @@ def check_standard_opening_times_updated(expected_value: list[dict]) -> None:
                 seconds_str in new_history[cms_key]["data"]["add"]
             ), f"Expected data: {seconds_str}, Actual data: {new_history[cms_key]['data']['add']}"
 
-    service_id = get_service_id_for_ods_code(DEFAULT_ODS_CODE)
-    assert_field_updated()
-    assert_field_updated_in_history()
+    if not smoke_test_context.blank_opening_times:
+        service_id = get_service_id_for_ods_code(DEFAULT_ODS_CODE)
+        assert_field_updated()
+        assert_field_updated_in_history()
 
 
 def check_specified_opening_times_updated(expected_value: list[dict]) -> None:

--- a/test/smoke/functions/smoke_test_context.py
+++ b/test/smoke/functions/smoke_test_context.py
@@ -11,3 +11,4 @@ class SmokeTestContext:
     original_service: ChangeEvent | None = None
     updated_service: ChangeEvent | None = None
     request_start_time: datetime | None = None
+    blank_opening_times: bool = False

--- a/test/smoke/test_steps.py
+++ b/test/smoke/test_steps.py
@@ -111,6 +111,11 @@ def _(smoke_test_context: SmokeTestContext) -> SmokeTestContext:
     Returns:
         SmokeTestContext: The smoke test context
     """
+    if not smoke_test_context.original_service.standard_opening_times:
+        smoke_test_context.blank_opening_times = True
+        smoke_test_context.original_service.standard_opening_times = (
+            smoke_test_context.updated_service.standard_opening_times
+        )
     smoke_test_context.updated_service = smoke_test_context.original_service
     return smoke_test_context
 
@@ -171,5 +176,7 @@ def _(smoke_test_context: SmokeTestContext) -> None:
         service_history_key="cmstelephoneno",
         expected_value=smoke_test_context.updated_service.phone,
     )
-    check_standard_opening_times_updated(expected_value=smoke_test_context.updated_service.standard_opening_times)
+    check_standard_opening_times_updated(
+        expected_value=smoke_test_context.updated_service.standard_opening_times, smoke_test_context=smoke_test_context,
+    )
     check_specified_opening_times_updated(expected_value=smoke_test_context.updated_service.specified_opening_times)


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1655>**

## Description of Changes

This PR allows the smoke test to work when the initial state of a service has a blank opening time.