### PR TITLE
DS-1602 Add Repository Security Policy

### DIFF
--- a/.github/workflows/SECURITY.md
+++ b/.github/workflows/SECURITY.md
@@ -1,0 +1,34 @@
+# Security
+
+NHS England takes security and the protection of private data extremely seriously. If you believe you have found a vulnerability or other issue which has compromised or could compromise the security of any of our systems and/or private data managed by our systems, please do not hesitate to contact us using the methods outlined below.
+
+## Table of Contents
+
+- [Security](#security)
+  - [Table of Contents](#table-of-contents)
+  - [Reporting a vulnerability](#reporting-a-vulnerability)
+    - [Email](#email)
+    - [NCSC](#ncsc)
+  - [General Security Enquiries](#general-security-enquiries)
+
+## Reporting a vulnerability
+
+Please note, email is our preferred method of receiving reports.
+
+### Email
+
+If you wish to notify us of a vulnerability via email, please include detailed information on the nature of the vulnerability and any steps required to reproduce it.
+
+You can reach us at:
+
+- [cybersecurity@nhs.net](cybersecurity@nhs.net)
+
+### NCSC
+
+You can send your report to the National Cyber Security Centre, who will assess your report and pass it on to NHS England if necessary.
+
+You can report vulnerabilities here: [https://www.ncsc.gov.uk/information/vulnerability-reporting](https://www.ncsc.gov.uk/information/vulnerability-reporting)
+
+## General Security Enquiries
+
+If you have general enquiries regarding our cyber security, please reach out to us at [cybersecurity@nhs.net](cybersecurity@nhs.net)

--- a/.github/workflows/configs/markdown-check-links.json
+++ b/.github/workflows/configs/markdown-check-links.json
@@ -12,6 +12,9 @@
     },
     {
       "pattern": "^https://ddc-exeter-data-clone-prod-ddc-data-clone.k8s-prod.texasplatform.uk/"
+    },
+    {
+      "pattern": "^*@nhs.net"
     }
   ],
   "timeout": "5s"


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1602>**

## Description of Changes

This PR adds the default NHS Security Policy from the template repository which can be found here -> https://github.com/nhs-england-tools/repository-template/blob/main/.github/SECURITY.md