### PR TITLE
DS-1633 Upgrade Terraform S3 Module Version

### DIFF
--- a/infrastructure/modules/s3/main.tf
+++ b/infrastructure/modules/s3/main.tf
@@ -8,7 +8,7 @@
 #tfsec:ignore:aws-s3-specify-public-access-block
 module "s3_bucket" {
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "3.4.0"
+  version = "3.15.1"
   bucket  = var.name
   acl     = var.acl
 


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1633>**

## Description of Changes

This PR upgrade the version of the S3 used to store emails and logs of s3 usage. From `3.4.0` to `3.15.1`