### PR TITLE
DS-1909 Modify Alarms To Not Deploy Into Task Environments

### DIFF
--- a/infrastructure/stacks/blue-green-link/cloudwatch-alarms.tf
+++ b/infrastructure/stacks/blue-green-link/cloudwatch-alarms.tf
@@ -15,7 +15,7 @@ resource "aws_cloudwatch_metric_alarm" "service_matcher_invalid_postcode_alert" 
 }
 
 resource "aws_cloudwatch_metric_alarm" "service_matcher_invalid_opening_times_alert" {
-  count               = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count               = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions       = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description   = "Events received from NHS UK with invalid opening times"
   alarm_name          = "${var.project_id} | ${var.blue_green_environment} | Invalid Opening Times"
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "service_matcher_invalid_opening_times_al
 }
 
 resource "aws_cloudwatch_metric_alarm" "holiding_sqs_dlq_alert" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when the Holding Queue Message DLQ has recieved messages"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Holding Queue Message DLQ'd"
@@ -49,7 +49,7 @@ resource "aws_cloudwatch_metric_alarm" "holiding_sqs_dlq_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "update_request_dlq_alert" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when the Update Request DLQ has recieved messages"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Update Requests DLQ'd"
@@ -66,7 +66,7 @@ resource "aws_cloudwatch_metric_alarm" "update_request_dlq_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_number_of_change_events_alert" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert when the DI has recieved a high number of change events"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | High Number of Change Events received"
@@ -84,7 +84,7 @@ resource "aws_cloudwatch_metric_alarm" "high_number_of_change_events_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_number_of_update_requests_waiting_alert" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when DI is waiting to process update requests in service sync"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Update Requests Waiting"
@@ -101,7 +101,7 @@ resource "aws_cloudwatch_metric_alarm" "high_number_of_update_requests_waiting_a
 }
 
 resource "aws_cloudwatch_metric_alarm" "high_number_of_failed_emails_alert" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when DI is failing to send emails"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Failed Emails"
@@ -118,7 +118,7 @@ resource "aws_cloudwatch_metric_alarm" "high_number_of_failed_emails_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "average_message_latency_alert" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when the Latency for when changes are taken to long to process and save"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Average Message Latency"
@@ -137,7 +137,7 @@ resource "aws_cloudwatch_metric_alarm" "average_message_latency_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "maximum_message_latency_alert" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when DI is taking longer than expected to process update requests"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Maximum Message Latency"
@@ -156,7 +156,7 @@ resource "aws_cloudwatch_metric_alarm" "maximum_message_latency_alert" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "dos_palliative_care_z_code_does_not_exist" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when the DoS Palliative Care Z Code does not exist"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | DoS Palliative Care Z Code Does Not Exist !!!"
@@ -173,7 +173,7 @@ resource "aws_cloudwatch_metric_alarm" "dos_palliative_care_z_code_does_not_exis
 }
 
 resource "aws_cloudwatch_metric_alarm" "dos_blood_pressure_z_code_does_not_exist" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when the DoS Blood Pressure Z Code does not exist"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | DoS Blood Pressure Z Code Does Not Exist !!!"
@@ -190,7 +190,7 @@ resource "aws_cloudwatch_metric_alarm" "dos_blood_pressure_z_code_does_not_exist
 }
 
 resource "aws_cloudwatch_metric_alarm" "dos_contraception_z_code_does_not_exist" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
   alarm_description         = "Alert for when the DoS Contraception Z Code does not exist"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | DoS Contraception Z Code Does Not Exist !!!"
@@ -207,7 +207,7 @@ resource "aws_cloudwatch_metric_alarm" "dos_contraception_z_code_does_not_exist"
 }
 
 resource "aws_cloudwatch_metric_alarm" "notify_when_quality_checker_has_completed" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_description         = "Alert for when the Quality Checker has completed"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Quality Checker Has Completed"
   comparison_operator       = "LessThanThreshold"
@@ -225,7 +225,7 @@ resource "aws_cloudwatch_metric_alarm" "notify_when_quality_checker_has_complete
 }
 
 resource "aws_cloudwatch_metric_alarm" "notify_when_quality_checker_has_errorred" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_description         = "Alert for when the Quality Checker has errorred"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Quality Checker Has Errorred"
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]
@@ -243,7 +243,7 @@ resource "aws_cloudwatch_metric_alarm" "notify_when_quality_checker_has_errorred
 }
 
 resource "aws_cloudwatch_metric_alarm" "notify_when_quality_checker_schedule_failed_invocation" {
-  count                     = var.profile == "dev" && var.blue_green_environment != "test" ? 0 : 1
+  count                     = can(regex("ds-*", var.blue_green_environment)) ? 0 : 1
   alarm_description         = "Alert for when the Quality Checker Schedule has failed invocation"
   alarm_name                = "${var.project_id} | ${var.blue_green_environment} | Quality Checker Schedule Failed Invocation"
   alarm_actions             = [data.aws_sns_topic.sns_topic_app_alerts_for_slack_default_region.arn]


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1909>**

## Description of Changes

This PR modifies the alarms to not deploy into Task environments and fixes where the alarms are incorrectly not deployed into the release/cicd-test environments.