### PR TITLE
DS-1977 Update CodeBuild To Use Local BuildSpecs

### DIFF
--- a/infrastructure/stacks/development-and-deployment-tools/build_cicd_blue_green_deployment_artefact.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/build_cicd_blue_green_deployment_artefact.tf
@@ -74,7 +74,7 @@ resource "aws_codebuild_project" "build_cicd_blue_green_artefact" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = file("buildspecs/build-cicd-blue-green-deployment-artefact-buildspec.yml")
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/buildspecs/build-cicd-blue-green-deployment-artefact-buildspec.yml"
   }
   depends_on = [module.cicd_blue_green_deployment_pipeline_artefact_bucket]
 }

--- a/infrastructure/stacks/development-and-deployment-tools/build_cicd_shared_resources_artefact.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/build_cicd_shared_resources_artefact.tf
@@ -70,7 +70,7 @@ resource "aws_codebuild_project" "build_cicd_shared_resources_artefact" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = file("buildspecs/build-cicd-shared-resources-artefact-buildspec.yml")
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/buildspecs/build-cicd-shared-resources-artefact-buildspec.yml"
   }
   depends_on = [
     module.cicd_shared_resoures_deployment_pipeline_artefact_bucket

--- a/infrastructure/stacks/development-and-deployment-tools/build_deploy_test_release.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/build_deploy_test_release.tf
@@ -70,7 +70,7 @@ resource "aws_codebuild_project" "build_deploy_test_release" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = file("batch-buildspecs/build-deploy-test-release-buildspec.yml")
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/build-deploy-test-release-buildspec.yml"
   }
 
 }

--- a/infrastructure/stacks/development-and-deployment-tools/build_tools_image.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/build_tools_image.tf
@@ -89,6 +89,6 @@ resource "aws_codebuild_project" "build_image" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = file("buildspecs/build-tools-image-buildspec.yml")
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/buildspecs/build-tools-image-buildspec.yml"
   }
 }

--- a/infrastructure/stacks/development-and-deployment-tools/cicd_blue_green_rollback.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/cicd_blue_green_rollback.tf
@@ -62,7 +62,7 @@ resource "aws_codebuild_project" "blue_green_rollback_stage" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = file("buildspecs/rollback-blue-green-deployment-buildspec.yml")
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/buildspecs/rollback-blue-green-deployment-buildspec.yml"
   }
 
 }

--- a/infrastructure/stacks/development-and-deployment-tools/delete_blue_green_environment.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/delete_blue_green_environment.tf
@@ -39,6 +39,6 @@ resource "aws_codebuild_project" "delete_blue_green_environment" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = file("buildspecs/delete-blue-green-environment-buildspec.yml")
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/buildspecs/delete-blue-green-environment-buildspec.yml"
   }
 }

--- a/infrastructure/stacks/development-and-deployment-tools/delete_nonprod_environment_from_tag.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/delete_nonprod_environment_from_tag.tf
@@ -65,7 +65,7 @@ resource "aws_codebuild_project" "destroy_environment_from_tag" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = file("buildspecs/delete-nonprod-environment-from-tag-buildspec.yml")
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/buildspecs/delete-nonprod-environment-from-tag-buildspec.yml"
   }
 
 }

--- a/infrastructure/stacks/development-and-deployment-tools/delete_nonprod_environment_on_pr_merged.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/delete_nonprod_environment_on_pr_merged.tf
@@ -64,7 +64,7 @@ resource "aws_codebuild_project" "destroy_nonprod_environment_on_pr_merged" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = file("buildspecs/delete-nonprod-environment-on-pr-merged-buildspec.yml")
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/buildspecs/delete-nonprod-environment-on-pr-merged-buildspec.yml"
   }
 
 }

--- a/infrastructure/stacks/development-and-deployment-tools/pipeline_stages.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/pipeline_stages.tf
@@ -43,7 +43,7 @@ resource "aws_codebuild_project" "unit_tests_stage" {
   }
   source {
     type      = "CODEPIPELINE"
-    buildspec = file("buildspecs/unit-tests-buildspec.yml")
+    buildspec = "infrastructure/stacks/development-and-deployment-tools/buildspecs/unit-tests-buildspec.yml"
   }
 }
 
@@ -88,7 +88,7 @@ resource "aws_codebuild_project" "build_image_stage" {
   }
   source {
     type      = "CODEPIPELINE"
-    buildspec = file("buildspecs/build-arm-image-in-pipeline-buildspec.yml")
+    buildspec = "infrastructure/stacks/development-and-deployment-tools/buildspecs/build-arm-image-in-pipeline-buildspec.yml"
   }
 }
 
@@ -128,7 +128,7 @@ resource "aws_codebuild_project" "full_deploy_stage" {
   }
   source {
     type      = "CODEPIPELINE"
-    buildspec = file("buildspecs/deploy-full-environment-buildspec.yml")
+    buildspec = "infrastructure/stacks/development-and-deployment-tools/buildspecs/deploy-full-environment-buildspec.yml"
   }
 }
 
@@ -183,7 +183,7 @@ resource "aws_codebuild_project" "deploy_blue_green_environment_stage" {
   }
   source {
     type      = "CODEPIPELINE"
-    buildspec = file("buildspecs/deploy-blue-green-environment-buildspec.yml")
+    buildspec = "infrastructure/stacks/development-and-deployment-tools/buildspecs/deploy-blue-green-environment-buildspec.yml"
   }
   depends_on = [
     aws_codebuild_project.delete_blue_green_environment
@@ -226,7 +226,7 @@ resource "aws_codebuild_project" "deploy_shared_resources_environment_stage" {
   }
   source {
     type      = "CODEPIPELINE"
-    buildspec = file("buildspecs/deploy-shared-resources-environment-buildspec.yml")
+    buildspec = "infrastructure/stacks/development-and-deployment-tools/buildspecs/deploy-shared-resources-environment-buildspec.yml"
   }
 }
 
@@ -275,7 +275,7 @@ resource "aws_codebuild_project" "integration_tests" {
   }
   source {
     type      = "CODEPIPELINE"
-    buildspec = file("buildspecs/integration-tests-buildspec.yml")
+    buildspec = "infrastructure/stacks/development-and-deployment-tools/buildspecs/integration-tests-buildspec.yml"
   }
 }
 
@@ -328,7 +328,7 @@ resource "aws_codebuild_project" "trigger_rollback" {
   }
   source {
     type      = "CODEPIPELINE"
-    buildspec = file("buildspecs/trigger-rollback-buildspec.yml")
+    buildspec = "infrastructure/stacks/development-and-deployment-tools/buildspecs/trigger-rollback-buildspec.yml"
   }
 }
 
@@ -372,6 +372,6 @@ resource "aws_codebuild_project" "production_smoke_test" {
   }
   source {
     type      = "CODEPIPELINE"
-    buildspec = file("buildspecs/production-smoke-test-buildspec.yml")
+    buildspec = "infrastructure/stacks/development-and-deployment-tools/buildspecs/production-smoke-test-buildspec.yml"
   }
 }

--- a/infrastructure/stacks/development-and-deployment-tools/setup_dos_environment.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/setup_dos_environment.tf
@@ -62,7 +62,7 @@ resource "aws_codebuild_project" "setup_dos_environment" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = file("buildspecs/setup-dos-environment-buildspec.yml")
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/buildspecs/setup-dos-environment-buildspec.yml"
   }
   vpc_config {
     security_group_ids = [

--- a/infrastructure/stacks/development-and-deployment-tools/task_env_deploy_and_test.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/task_env_deploy_and_test.tf
@@ -70,6 +70,6 @@ resource "aws_codebuild_project" "task_env_deploy_and_test" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = file("batch-buildspecs/task-env-deploy-and-test-buildspec.yml")
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/batch-buildspecs/task-env-deploy-and-test-buildspec.yml"
   }
 }


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1977>**

## Description of Changes

This PR updates the CodeBuild jobs to use the local buildspec file rather than a stored buildspec. This allows changes to be made to a branch rather than the change made for all branches
