### PR TITLE
DS-1984 Fix Specified Opening Times Smoke Test Bug

### DIFF
--- a/test/smoke/test_steps.py
+++ b/test/smoke/test_steps.py
@@ -90,7 +90,7 @@ def _(smoke_test_context: SmokeTestContext) -> SmokeTestContext:
     def update_specified_opening_times() -> None:
         smoke_test_context.updated_service.specified_opening_times = [
             {
-                "date": FAKER.date_this_year(before_today=False, after_today=True),
+                "date": FAKER.date_this_decade(before_today=False, after_today=True),
                 "open": "09:00",
                 "close": "17:00",
                 "open_or_closed": True,


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1984>**

## Description of Changes

This PR fixes a bug with the Smoke Test which the specified opening times picks a date between now and the end of the year. As the year get closer to ending such as December less dates can be picked without picking a duplicate. So I've set the function to use `date_this_decade` which reduces the chance of the same date being picked twice.