### PR TITLE
DS-1987 Fix Missing Release Deploy and Test BuildSpec

### DIFF
--- a/infrastructure/stacks/development-and-deployment-tools/build_deploy_test_release.tf
+++ b/infrastructure/stacks/development-and-deployment-tools/build_deploy_test_release.tf
@@ -70,7 +70,7 @@ resource "aws_codebuild_project" "build_deploy_test_release" {
     type            = "GITHUB"
     git_clone_depth = 0
     location        = var.github_url
-    buildspec       = "infrastructure/stacks/development-and-deployment-tools/build-deploy-test-release-buildspec.yml"
+    buildspec       = "infrastructure/stacks/development-and-deployment-tools/batch-buildspecs/build-deploy-test-release-buildspec.yml"
   }
 
 }


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-1987>**

## Description of Changes

This PR fixes the `build-deploy-test-release` CodeBuild job using the incorrect path to the buildspec.