### PR TITLE
DS-2244 Add Penetration Test Make Profile

### DIFF
--- a/build/automation/var/profile/pen.mk
+++ b/build/automation/var/profile/pen.mk
@@ -1,0 +1,4 @@
+-include $(VAR_DIR)/profile/dev.mk
+
+# WAF
+WAF_ENABLED := true


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-2244>**

## Description of Changes

This change adds a penetration test profile call pen.mk. This profile is based of the dev.mk profile but enables the WAF.