### PR TITLE
DS-2408 Add image build security scan fix to missed pipelines

### DIFF
--- a/infrastructure/stacks/development-and-deployment-tools/buildspecs/build-arm-image-from-webhook-buildspec.yml
+++ b/infrastructure/stacks/development-and-deployment-tools/buildspecs/build-arm-image-from-webhook-buildspec.yml
@@ -35,4 +35,6 @@ phases:
       - unset AWS_SECRET_ACCESS_KEY
       - unset AWS_SESSION_TOKEN
       - make docker-push NAME=$BUILD_ITEM_NAME VERSION=$(make commit-date-hash-tag)
+      # Temp solution for issue with the scan not being available in time for the aws-ecr-get-security-scan make target
+      - sleep 20
       - make aws-ecr-get-security-scan REPOSITORY=$BUILD_ITEM_NAME TAG=$(make commit-date-hash-tag) SHOW_ALL_WARNINGS=true FAIL_ON_WARNINGS=true

--- a/infrastructure/stacks/development-and-deployment-tools/buildspecs/build-arm-image-in-pipeline-buildspec.yml
+++ b/infrastructure/stacks/development-and-deployment-tools/buildspecs/build-arm-image-in-pipeline-buildspec.yml
@@ -26,4 +26,6 @@ phases:
       - unset AWS_SECRET_ACCESS_KEY
       - unset AWS_SESSION_TOKEN
       - make docker-push NAME=$BUILD_ITEM_NAME VERSION=$CODEBUILD_RESOLVED_SOURCE_VERSION
+      # Temp solution for issue with the scan not being available in time for the aws-ecr-get-security-scan make target
+      - sleep 20
       - make aws-ecr-get-security-scan REPOSITORY=$BUILD_ITEM_NAME TAG=$CODEBUILD_RESOLVED_SOURCE_VERSION SHOW_ALL_WARNINGS=true FAIL_ON_WARNINGS=true


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-2408>**

## Description of Changes

This PR adds a temp fix to the missed build image codebuild jobs used by DI's pipelines. A 20 second sleep has been put in place to give time for the aws ecr security image scan to be ready, before it's checked.


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester