### PR TITLE
DS-2622 Remove last missed ECR vulnerability scan check

### DIFF
--- a/infrastructure/stacks/development-and-deployment-tools/buildspecs/build-arm-image-in-pipeline-buildspec.yml
+++ b/infrastructure/stacks/development-and-deployment-tools/buildspecs/build-arm-image-in-pipeline-buildspec.yml
@@ -26,6 +26,3 @@ phases:
       - unset AWS_SECRET_ACCESS_KEY
       - unset AWS_SESSION_TOKEN
       - make docker-push NAME=$BUILD_ITEM_NAME VERSION=$CODEBUILD_RESOLVED_SOURCE_VERSION
-      # Temp solution for issue with the scan not being available in time for the aws-ecr-get-security-scan make target
-      - sleep 20
-      - make aws-ecr-get-security-scan REPOSITORY=$BUILD_ITEM_NAME TAG=$CODEBUILD_RESOLVED_SOURCE_VERSION SHOW_ALL_WARNINGS=true FAIL_ON_WARNINGS=true


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-2622>**

## Description of Changes

Removes last ECR vulnerability scan check from the development pipeline, missed from previous two DS-2622 branches. The last one only removed it from webhook based buildspec.

Reason from removal can be found in the ticket. 

## Type of change

Delete not appropriate

- Bug fix (non-breaking change which fixes an issue)

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester