### PR TITLE
DS-2834 Restricted endpoint to security group

### DIFF
--- a/infrastructure/stacks/application/security_groups.tf
+++ b/infrastructure/stacks/application/security_groups.tf
@@ -11,24 +11,24 @@ resource "aws_security_group" "lambda_sg" {
 
 #tfsec:ignore:aws-vpc-no-public-egress-sgr
 resource "aws_security_group_rule" "allow_https_out" {
-  type              = "egress"
-  from_port         = 443
-  to_port           = 443
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.lambda_sg.id
-  description       = "Allow all HTTPS outbound traffic"
+  type                     = "egress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  source_security_group_id = data.aws_security_group.db_sg.id
+  security_group_id        = aws_security_group.lambda_sg.id
+  description              = "Allow all HTTPS outbound traffic"
 }
 
 #tfsec:ignore:aws-vpc-no-public-egress-sgr
 resource "aws_security_group_rule" "allow_postgres_out" {
-  type              = "egress"
-  from_port         = 5432
-  to_port           = 5432
-  protocol          = "tcp"
-  cidr_blocks       = ["0.0.0.0/0"]
-  security_group_id = aws_security_group.lambda_sg.id
-  description       = "Allow all Postgres outbound traffic"
+  type                     = "egress"
+  from_port                = 5432
+  to_port                  = 5432
+  protocol                 = "tcp"
+  source_security_group_id = data.aws_security_group.db_sg.id
+  security_group_id        = aws_security_group.lambda_sg.id
+  description              = "Allow all Postgres outbound traffic"
 }
 
 resource "aws_security_group_rule" "database_allow_in_from_lambda" {

--- a/infrastructure/stacks/application/security_groups.tf
+++ b/infrastructure/stacks/application/security_groups.tf
@@ -11,13 +11,13 @@ resource "aws_security_group" "lambda_sg" {
 
 #tfsec:ignore:aws-vpc-no-public-egress-sgr
 resource "aws_security_group_rule" "allow_https_out" {
-  type                     = "egress"
-  from_port                = 443
-  to_port                  = 443
-  protocol                 = "tcp"
-  source_security_group_id = data.aws_security_group.db_sg.id
-  security_group_id        = aws_security_group.lambda_sg.id
-  description              = "Allow all HTTPS outbound traffic"
+  type              = "egress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  cidr_blocks       = ["0.0.0.0/0"]
+  security_group_id = aws_security_group.lambda_sg.id
+  description       = "Allow all HTTPS outbound traffic"
 }
 
 #tfsec:ignore:aws-vpc-no-public-egress-sgr


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-2834>**

## Description of Changes

Changed rule for port 5432 to only point to the dos-integration security group rather than any IP address.
## Type of change

- Bug fix (PEN test change)

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester