### PR TITLE
DS-2843 Enable dynamodb delete protection for live profile

### DIFF
--- a/build/automation/var/profile/demo.mk
+++ b/build/automation/var/profile/demo.mk
@@ -40,6 +40,7 @@ SLACK_ALERT_CHANNEL := dos-integration-dev-status
 
 # WAF
 WAF_ENABLED := true
+DDB_DELETE_PROTECTION :=false
 
 # ==============================================================================
 # Performance variables

--- a/build/automation/var/profile/dev.mk
+++ b/build/automation/var/profile/dev.mk
@@ -39,6 +39,7 @@ SLACK_ALERT_CHANNEL := dos-integration-dev-status
 
 # WAF
 WAF_ENABLED := false
+DDB_DELETE_PROTECTION :=true
 
 # ==============================================================================
 # Performance variables

--- a/build/automation/var/profile/dev.mk
+++ b/build/automation/var/profile/dev.mk
@@ -39,7 +39,7 @@ SLACK_ALERT_CHANNEL := dos-integration-dev-status
 
 # WAF
 WAF_ENABLED := false
-DDB_DELETE_PROTECTION :=true
+DDB_DELETE_PROTECTION :=false
 
 # ==============================================================================
 # Performance variables

--- a/build/automation/var/profile/live.mk
+++ b/build/automation/var/profile/live.mk
@@ -41,6 +41,7 @@ SLACK_ALERT_CHANNEL := dos-integration-live-status
 
 # WAF
 WAF_ENABLED := true
+DDB_DELETE_PROTECTION :=true
 
 # ==============================================================================
 # Performance variables

--- a/build/automation/var/profile/pen.mk
+++ b/build/automation/var/profile/pen.mk
@@ -2,3 +2,4 @@
 
 # WAF
 WAF_ENABLED := true
+DDB_DELETE_PROTECTION :=false

--- a/build/automation/var/profile/perf.mk
+++ b/build/automation/var/profile/perf.mk
@@ -39,6 +39,7 @@ SLACK_ALERT_CHANNEL := dos-integration-dev-status
 
 # WAF
 WAF_ENABLED := true
+DDB_DELETE_PROTECTION :=false
 
 # ==============================================================================
 # Performance variables

--- a/build/automation/var/profile/perf2.mk
+++ b/build/automation/var/profile/perf2.mk
@@ -39,6 +39,7 @@ SLACK_ALERT_CHANNEL := dos-integration-dev-status
 
 # WAF
 WAF_ENABLED := true
+DDB_DELETE_PROTECTION :=false
 
 # ==============================================================================
 # Performance variables

--- a/build/automation/var/project.mk
+++ b/build/automation/var/project.mk
@@ -109,6 +109,7 @@ TF_VAR_change_event_dlq := $(PROJECT_ID)-$(SHARED_ENVIRONMENT)-change-event-dead
 # Dynamodb
 TF_VAR_change_events_table_name := $(PROJECT_ID)-$(SHARED_ENVIRONMENT)-change-events
 DYNAMO_DB_TABLE := $(TF_VAR_change_events_table_name)
+TF_VAR_ddb_delete_protection :=$(DDB_DELETE_PROTECTION)
 
 # Log Group Filters for Firehose
 TF_VAR_change_event_gateway_subscription_filter_name := $(PROJECT_ID)-$(SHARED_ENVIRONMENT)-change-event-api-gateway-cw-logs-firehose-subscription
@@ -128,7 +129,6 @@ TF_VAR_shared_resources_sns_topic_app_alerts_for_slack_route53_health_check_alar
 
 # WAF
 TF_VAR_waf_enabled := $(WAF_ENABLED)
-TF_VAR_ddb_delete_protection :=$(DDB_DELETE_PROTECTION)
 TF_VAR_waf_acl_name := $(PROJECT_ID)-$(SHARED_ENVIRONMENT)-waf-acl
 TF_VAR_waf_log_group_name := aws-waf-logs-$(PROJECT_ID)-$(SHARED_ENVIRONMENT)-waf-log-group
 TF_VAR_waf_log_subscription_filter_name := $(PROJECT_ID)-$(SHARED_ENVIRONMENT)-waf-log-subscription-filter

--- a/build/automation/var/project.mk
+++ b/build/automation/var/project.mk
@@ -128,6 +128,7 @@ TF_VAR_shared_resources_sns_topic_app_alerts_for_slack_route53_health_check_alar
 
 # WAF
 TF_VAR_waf_enabled := $(WAF_ENABLED)
+TF_VAR_ddb_delete_protection :=$(DDB_DELETE_PROTECTION)
 TF_VAR_waf_acl_name := $(PROJECT_ID)-$(SHARED_ENVIRONMENT)-waf-acl
 TF_VAR_waf_log_group_name := aws-waf-logs-$(PROJECT_ID)-$(SHARED_ENVIRONMENT)-waf-log-group
 TF_VAR_waf_log_subscription_filter_name := $(PROJECT_ID)-$(SHARED_ENVIRONMENT)-waf-log-subscription-filter

--- a/infrastructure/stacks/shared-resources/dynamodb.tf
+++ b/infrastructure/stacks/shared-resources/dynamodb.tf
@@ -3,6 +3,7 @@ resource "aws_dynamodb_table" "message-history-table" {
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "Id"
   range_key    = "ODSCode"
+  deletion_protection_enabled = var.ddb_delete_protection
 
   server_side_encryption {
     enabled     = true

--- a/infrastructure/stacks/shared-resources/variables.tf
+++ b/infrastructure/stacks/shared-resources/variables.tf
@@ -158,6 +158,11 @@ variable "waf_enabled" {
   description = "Whether to enable WAF"
 }
 
+variable "ddb_delete_protection" {
+  type        = bool
+  description = "Whether to enable delete protection"
+}
+
 variable "waf_acl_name" {
   type        = string
   description = "Name of the WAF ACL"


### PR DESCRIPTION
# Task Branch Pull Request

**<https://nhsd-jira.digital.nhs.uk/browse/DS-2843>**

## Description of Changes

This PR change enables the delete protection on change event DB in prod environment. This delete protection not enabled on any other env as we will require to tear the lower envs down after the development/testing purpose is fulfilled and tested in these lower env and hence it's enabled for prod env only to avoid accidental deletion of DB
## Type of change

Delete not appropriate

- Security enhancement for dynamodb table in prod env

## Development Checklist

- [x] I have performed a self-review of my own code
- [x] Tests have added that prove my fix is effective or that my feature works (Integration tests)
- [x] I have updated Dependabot to include my changes (if applicable)

## Code Reviewer Checklist

- [x] I can confirm the changes have been tested or approved by a tester